### PR TITLE
Adding some descriptive error handling around CacheProfile options, i…

### DIFF
--- a/Source/Content/ApiTemplate/ApplicationBuilderExtensions.cs
+++ b/Source/Content/ApiTemplate/ApplicationBuilderExtensions.cs
@@ -30,11 +30,23 @@ namespace ApiTemplate
         /// </summary>
         public static IApplicationBuilder UseStaticFilesWithCacheControl(this IApplicationBuilder application)
         {
-            var cacheProfile = application
-                .ApplicationServices
-                .GetRequiredService<CacheProfileOptions>()
-                .First(x => string.Equals(x.Key, CacheProfileName.StaticFiles, StringComparison.Ordinal))
-                .Value;
+	        var cacheProfileOptions = application
+		        .ApplicationServices
+		        .GetRequiredService<CacheProfileOptions>();
+
+	        if(!cacheProfileOptions.TryGetValue(CacheProfileName.StaticFiles, out var cacheProfile))
+		        throw new Exception(
+			        $@"Please make sure that you have a CacheProfile setting configured in the with a '{CacheProfileName.StaticFiles}' section, such as in your appsetting.json, E.g.
+  
+  ""CacheProfiles"": {{
+    // Cache static files for a year.
+    ""StaticFiles"": {{
+      ""Duration"": 31536000,
+      ""Location"": ""Any""
+    }}
+  }},
+
+");
             return application
                 .UseStaticFiles(
                     new StaticFileOptions()


### PR DESCRIPTION
…n case they are missing

This occurred to me when trying to run a test, as the test project had its own appsettings.json