### PR TITLE
Handle nullable value types in cursor

### DIFF
--- a/Source/Content/GraphQLTemplate/Cursor.cs
+++ b/Source/Content/GraphQLTemplate/Cursor.cs
@@ -24,8 +24,11 @@ namespace GraphQLTemplate
             {
                 return default;
             }
-
-            return (T)Convert.ChangeType(decodedValue, typeof(T), CultureInfo.InvariantCulture);
+            
+            var type = typeof(T);
+            type = Nullable.GetUnderlyingType(type) ?? type;
+            
+            return (T)Convert.ChangeType(decodedValue, type, CultureInfo.InvariantCulture);
         }
 
         public static (string firstCursor, string lastCursor) GetFirstAndLastCursor<TItem, TCursor>(

--- a/Tests/Boxed.Templates.Test/GraphQLTemplate/CursorTest.cs
+++ b/Tests/Boxed.Templates.Test/GraphQLTemplate/CursorTest.cs
@@ -9,11 +9,24 @@ namespace Boxed.Templates.Test.GraphQLTemplate
     {
         [Theory]
         [InlineData("MA=", 0)]
+        [InlineData("MA==", 0)]
         [InlineData("NQ==", 5)]
         [InlineData("LTU=", -5)]
         public void FromCursor_IntValue_ReturnsPrefixedBase64Cursor(string cursor, int expectedValue)
         {
             var value = Cursor.FromCursor<int>(cursor);
+
+            Assert.Equal(expectedValue, value);
+        }
+
+        [Theory]
+        [InlineData("MA=", null)]
+        [InlineData("MA==", 0)]
+        [InlineData("NQ==", 5)]
+        [InlineData("LTU=", -5)]
+        public void FromCursor_NullableIntValue_ReturnsPrefixedBase64Cursor(string cursor, int? expectedValue)
+        {
+            var value = Cursor.FromCursor<int?>(cursor);
 
             Assert.Equal(expectedValue, value);
         }
@@ -125,6 +138,16 @@ namespace Boxed.Templates.Test.GraphQLTemplate
         {
             var cursor = Cursor.ToCursor(value);
 
+            Assert.Equal(expectedCursor, cursor);
+        }
+
+        [Theory]
+        [InlineData(0, "MA==")]
+        [InlineData(5, "NQ==")]
+        [InlineData(-5, "LTU=")]
+        public void ToCursor_NullableIntValue_ReturnsPrefixedBase64Cursor(int? value, string expectedCursor)
+        {
+            var cursor = Cursor.ToCursor(value);
             Assert.Equal(expectedCursor, cursor);
         }
 


### PR DESCRIPTION
I want to see if there's a way to check if a type is nullable before doing the `Nullable.GetUnderlyingType(type)` but haven't found anything yet.

Anyway, this solved an issue for me where I want to parse the value as an `int?`.