### PR TITLE
Setting Swagger host attribute

### DIFF
--- a/Source/Content/ApiTemplate/Source/ApiTemplate/Startup.cs
+++ b/Source/Content/ApiTemplate/Source/ApiTemplate/Startup.cs
@@ -150,7 +150,10 @@ namespace ApiTemplate
                 .UseStaticFilesWithCacheControl()
 #if (Swagger)
                 .UseMvc()
-                .UseSwagger()
+                .UseSwagger(c =>
+                {
+                    c.PreSerializeFilters.Add((swaggerDoc, httpReq) => swaggerDoc.Host = httpReq.Host.Value);
+                })
                 .UseCustomSwaggerUI();
 #else
                 .UseMvc();


### PR DESCRIPTION
Fix for Issue #306 

Now setting the swagger host attribute from the request, as explained here https://github.com/domaindrivendev/Swashbuckle.AspNetCore#modify-swagger-with-request-context


