### PR TITLE
Remove hard coded path to Boxed.Templates.csproj file.

### DIFF
--- a/build.cake
+++ b/build.cake
@@ -17,6 +17,7 @@ var buildNumber =
     0;
 
 var artifactsDirectory = Directory("./Artifacts");
+var templatePackProject = Directory("./Source/*.csproj");
 var versionSuffix = string.IsNullOrEmpty(preReleaseSuffix) ? null : preReleaseSuffix + "-" + buildNumber.ToString("D4");
 
 Task("Clean")
@@ -69,7 +70,7 @@ Task("Pack")
     .Does(() =>
     {
         DotNetCorePack(
-            GetFiles("**/Boxed.Templates.csproj").First().ToString(),
+            GetFiles(templatePackProject).Single().ToString(),
             new DotNetCorePackSettings()
             {
                 Configuration = configuration,


### PR DESCRIPTION
Use Single() instead of First() because we want this to blow up here and not somewhere inside DotNetCorePack()