### PR TITLE
Install developer certificate and fix dotnet run not cleaning up

### DIFF
--- a/Tests/Boxed.Templates.FunctionalTest/Framework/ProcessAssert.cs
+++ b/Tests/Boxed.Templates.FunctionalTest/Framework/ProcessAssert.cs
@@ -78,8 +78,9 @@ namespace Boxed.Templates.FunctionalTest
 
             if (!string.IsNullOrEmpty(standardError))
             {
-                stringBuilder.AppendLine();
-                stringBuilder.AppendLine($"StandardError: {standardError}");
+                stringBuilder
+                    .AppendLine()
+                    .AppendLine($"StandardError: {standardError}");
                 TestLogger.WriteLine("StandardError: ");
                 TestLogger.WriteLine(standardError, ConsoleColor.Red);
                 TestLogger.WriteLine();
@@ -87,8 +88,9 @@ namespace Boxed.Templates.FunctionalTest
 
             if (!string.IsNullOrEmpty(standardOutput))
             {
-                stringBuilder.AppendLine();
-                stringBuilder.AppendLine($"StandardOutput: {standardOutput}");
+                stringBuilder
+                    .AppendLine()
+                    .AppendLine($"StandardOutput: {standardOutput}");
                 TestLogger.WriteLine();
                 TestLogger.WriteLine($"StandardOutput: {standardOutput}");
             }
@@ -156,6 +158,7 @@ namespace Boxed.Templates.FunctionalTest
                     {
                         if (!process.HasExited)
                         {
+                            // Add process.Kill(true) when 3.0 comes out to kill the entire process tree.
                             process.Kill();
                         }
 

--- a/Tests/Boxed.Templates.FunctionalTest/Framework/ProcessAssert.cs
+++ b/Tests/Boxed.Templates.FunctionalTest/Framework/ProcessAssert.cs
@@ -159,7 +159,7 @@ namespace Boxed.Templates.FunctionalTest
                         if (!process.HasExited)
                         {
                             // Add process.Kill(true) when 3.0 comes out to kill the entire process tree.
-                            process.Kill();
+                            process.KillTree();
                         }
 
                         throw;
@@ -171,41 +171,6 @@ namespace Boxed.Templates.FunctionalTest
             catch (Exception exception)
             {
                 throw new ProcessStartException(processStartInfo, exception);
-            }
-        }
-
-        /// <summary>
-        /// Waits asynchronously for the process to exit.
-        /// </summary>
-        /// <param name="process">The process to wait for cancellation.</param>
-        /// <param name="cancellationToken">A cancellation token. If invoked, the task will return
-        /// immediately as cancelled.</param>
-        /// <returns>A Task representing waiting for the process to end.</returns>
-        private static Task WaitForExitAsync(
-            this Process process,
-            CancellationToken cancellationToken = default)
-        {
-            process.EnableRaisingEvents = true;
-
-            var taskCompletionSource = new TaskCompletionSource<object>();
-
-            process.Exited += OnExited;
-            if (cancellationToken != default)
-            {
-                cancellationToken.Register(
-                    () =>
-                    {
-                        process.Exited -= OnExited;
-                        taskCompletionSource.TrySetCanceled();
-                    });
-            }
-
-            return taskCompletionSource.Task;
-
-            void OnExited(object sender, EventArgs e)
-            {
-                process.Exited -= OnExited;
-                taskCompletionSource.TrySetResult(null);
             }
         }
 

--- a/Tests/Boxed.Templates.FunctionalTest/Framework/ProcessAssert.cs
+++ b/Tests/Boxed.Templates.FunctionalTest/Framework/ProcessAssert.cs
@@ -50,9 +50,6 @@ namespace Boxed.Templates.FunctionalTest
             var standardError = error.ToString();
 
             var message = GetAndWriteMessage(
-                fileName,
-                arguments,
-                workingDirectory,
                 result,
                 standardOutput,
                 standardError);
@@ -63,9 +60,6 @@ namespace Boxed.Templates.FunctionalTest
         }
 
         private static string GetAndWriteMessage(
-            string fileName,
-            string arguments,
-            string workingDirectory,
             ProcessResult result,
             string standardOutput,
             string standardError)
@@ -78,8 +72,9 @@ namespace Boxed.Templates.FunctionalTest
 
             if (!string.IsNullOrEmpty(standardError))
             {
-                stringBuilder.AppendLine();
-                stringBuilder.AppendLine($"StandardError: {standardError}");
+                stringBuilder
+                    .AppendLine()
+                    .AppendLine($"StandardError: {standardError}");
                 TestLogger.WriteLine("StandardError: ");
                 TestLogger.WriteLine(standardError, ConsoleColor.Red);
                 TestLogger.WriteLine();
@@ -87,8 +82,9 @@ namespace Boxed.Templates.FunctionalTest
 
             if (!string.IsNullOrEmpty(standardOutput))
             {
-                stringBuilder.AppendLine();
-                stringBuilder.AppendLine($"StandardOutput: {standardOutput}");
+                stringBuilder
+                    .AppendLine()
+                    .AppendLine($"StandardOutput: {standardOutput}");
                 TestLogger.WriteLine();
                 TestLogger.WriteLine($"StandardOutput: {standardOutput}");
             }
@@ -193,7 +189,7 @@ namespace Boxed.Templates.FunctionalTest
                     () =>
                     {
                         process.Exited -= OnExited;
-                        taskCompletionSource.TrySetCanceled();
+                        taskCompletionSource.SetCanceled();
                     });
             }
 
@@ -202,7 +198,7 @@ namespace Boxed.Templates.FunctionalTest
             void OnExited(object sender, EventArgs e)
             {
                 process.Exited -= OnExited;
-                taskCompletionSource.TrySetResult(null);
+                taskCompletionSource.SetResult(null);
             }
         }
 
@@ -230,7 +226,7 @@ namespace Boxed.Templates.FunctionalTest
                     if (e.Data == null)
                     {
                         removeHandler(handler);
-                        taskCompletionSource.TrySetResult(null);
+                        taskCompletionSource.SetResult(null);
                     }
                     else
                     {
@@ -246,7 +242,7 @@ namespace Boxed.Templates.FunctionalTest
                     () =>
                     {
                         removeHandler(handler);
-                        taskCompletionSource.TrySetCanceled();
+                        taskCompletionSource.SetCanceled();
                     });
             }
 

--- a/Tests/Boxed.Templates.FunctionalTest/Framework/ProcessAssert.cs
+++ b/Tests/Boxed.Templates.FunctionalTest/Framework/ProcessAssert.cs
@@ -50,6 +50,9 @@ namespace Boxed.Templates.FunctionalTest
             var standardError = error.ToString();
 
             var message = GetAndWriteMessage(
+                fileName,
+                arguments,
+                workingDirectory,
                 result,
                 standardOutput,
                 standardError);
@@ -60,6 +63,9 @@ namespace Boxed.Templates.FunctionalTest
         }
 
         private static string GetAndWriteMessage(
+            string fileName,
+            string arguments,
+            string workingDirectory,
             ProcessResult result,
             string standardOutput,
             string standardError)
@@ -72,9 +78,8 @@ namespace Boxed.Templates.FunctionalTest
 
             if (!string.IsNullOrEmpty(standardError))
             {
-                stringBuilder
-                    .AppendLine()
-                    .AppendLine($"StandardError: {standardError}");
+                stringBuilder.AppendLine();
+                stringBuilder.AppendLine($"StandardError: {standardError}");
                 TestLogger.WriteLine("StandardError: ");
                 TestLogger.WriteLine(standardError, ConsoleColor.Red);
                 TestLogger.WriteLine();
@@ -82,9 +87,8 @@ namespace Boxed.Templates.FunctionalTest
 
             if (!string.IsNullOrEmpty(standardOutput))
             {
-                stringBuilder
-                    .AppendLine()
-                    .AppendLine($"StandardOutput: {standardOutput}");
+                stringBuilder.AppendLine();
+                stringBuilder.AppendLine($"StandardOutput: {standardOutput}");
                 TestLogger.WriteLine();
                 TestLogger.WriteLine($"StandardOutput: {standardOutput}");
             }
@@ -189,7 +193,7 @@ namespace Boxed.Templates.FunctionalTest
                     () =>
                     {
                         process.Exited -= OnExited;
-                        taskCompletionSource.SetCanceled();
+                        taskCompletionSource.TrySetCanceled();
                     });
             }
 
@@ -198,7 +202,7 @@ namespace Boxed.Templates.FunctionalTest
             void OnExited(object sender, EventArgs e)
             {
                 process.Exited -= OnExited;
-                taskCompletionSource.SetResult(null);
+                taskCompletionSource.TrySetResult(null);
             }
         }
 
@@ -226,7 +230,7 @@ namespace Boxed.Templates.FunctionalTest
                     if (e.Data == null)
                     {
                         removeHandler(handler);
-                        taskCompletionSource.SetResult(null);
+                        taskCompletionSource.TrySetResult(null);
                     }
                     else
                     {
@@ -242,7 +246,7 @@ namespace Boxed.Templates.FunctionalTest
                     () =>
                     {
                         removeHandler(handler);
-                        taskCompletionSource.SetCanceled();
+                        taskCompletionSource.TrySetCanceled();
                     });
             }
 

--- a/Tests/Boxed.Templates.FunctionalTest/Framework/ProcessExtensions.cs
+++ b/Tests/Boxed.Templates.FunctionalTest/Framework/ProcessExtensions.cs
@@ -1,0 +1,162 @@
+namespace Boxed.Templates.FunctionalTest
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Diagnostics;
+    using System.IO;
+    using System.Runtime.InteropServices;
+    using System.Threading;
+    using System.Threading.Tasks;
+
+    /// <summary>
+    /// <see cref="Process"/> extension methods.
+    /// </summary>
+    public static class ProcessExtensions
+    {
+        private static readonly TimeSpan DefaultTimeout = TimeSpan.FromSeconds(30);
+        private static readonly bool IsWindows = RuntimeInformation.IsOSPlatform(OSPlatform.Windows);
+
+        // Add process.Kill(true) when 3.0 comes out to kill the entire process tree.
+        public static void KillTree(this Process process) => process.KillTree(DefaultTimeout);
+
+        public static void KillTree(this Process process, TimeSpan timeout)
+        {
+            if (IsWindows)
+            {
+                _ = RunProcessAndWaitForExit(
+                    "taskkill",
+                    $"/T /F /PID {process.Id}",
+                    timeout,
+                    out _);
+            }
+            else
+            {
+                var children = new HashSet<int>();
+                GetAllChildIdsUnix(process.Id, children, timeout);
+                foreach (var childId in children)
+                {
+                    KillProcessUnix(childId, timeout);
+                }
+
+                KillProcessUnix(process.Id, timeout);
+            }
+        }
+
+        public static Task StartAndWaitForExitAsync(this Process process)
+        {
+            var taskCompletionSource = new TaskCompletionSource<object>();
+
+            process.EnableRaisingEvents = true;
+
+            process.Exited += (s, a) =>
+            {
+                taskCompletionSource.SetResult(null);
+
+                process.Dispose();
+            };
+
+            _ = process.Start();
+
+            return taskCompletionSource.Task;
+        }
+
+        /// <summary>
+        /// Waits asynchronously for the process to exit.
+        /// </summary>
+        /// <param name="process">The process to wait for cancellation.</param>
+        /// <param name="cancellationToken">A cancellation token. If invoked, the task will return
+        /// immediately as cancelled.</param>
+        /// <returns>A Task representing waiting for the process to end.</returns>
+        public static Task WaitForExitAsync(
+            this Process process,
+            CancellationToken cancellationToken = default)
+        {
+            var taskCompletionSource = new TaskCompletionSource<object>();
+
+            process.EnableRaisingEvents = true;
+
+            process.Exited += OnExited;
+            if (cancellationToken != default)
+            {
+                cancellationToken.Register(
+                    () =>
+                    {
+                        process.Exited -= OnExited;
+                        taskCompletionSource.TrySetCanceled();
+                    });
+            }
+
+            return taskCompletionSource.Task;
+
+            void OnExited(object sender, EventArgs e)
+            {
+                process.Exited -= OnExited;
+                taskCompletionSource.TrySetResult(null);
+            }
+        }
+
+        private static void GetAllChildIdsUnix(int parentId, ISet<int> children, TimeSpan timeout)
+        {
+            var exitCode = RunProcessAndWaitForExit(
+                "pgrep",
+                $"-P {parentId}",
+                timeout,
+                out var stdout);
+
+            if (exitCode == 0 && !string.IsNullOrEmpty(stdout))
+            {
+                using (var reader = new StringReader(stdout))
+                {
+                    while (true)
+                    {
+                        var text = reader.ReadLine();
+                        if (text == null)
+                        {
+                            return;
+                        }
+
+                        if (int.TryParse(text, out var id))
+                        {
+                            children.Add(id);
+
+                            // Recursively get the children
+                            GetAllChildIdsUnix(id, children, timeout);
+                        }
+                    }
+                }
+            }
+        }
+
+        private static void KillProcessUnix(int processId, TimeSpan timeout) =>
+            RunProcessAndWaitForExit(
+                "kill",
+                $"-TERM {processId}",
+                timeout,
+                out _);
+
+        private static int RunProcessAndWaitForExit(string fileName, string arguments, TimeSpan timeout, out string stdout)
+        {
+            var startInfo = new ProcessStartInfo
+            {
+                FileName = fileName,
+                Arguments = arguments,
+                RedirectStandardOutput = true,
+                UseShellExecute = false,
+            };
+
+            var process = Process.Start(startInfo);
+
+            stdout = null;
+            if (process.WaitForExit((int)timeout.TotalMilliseconds))
+            {
+                stdout = process.StandardOutput.ReadToEnd();
+            }
+            else
+            {
+                process.Kill();
+            }
+
+            return process.ExitCode;
+        }
+    }
+}

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -26,6 +26,7 @@ build_script:
 - cmd: choco install dotnetcore-sdk --no-progress --confirm --version 2.2.301
 - pwsh: dotnet tool install --global Cake.Tool
 - pwsh: dotnet cake --target=Build
+- pwsh: dotnet cake --target=InstallDeveloperCertificate
 - pwsh: dotnet cake --target=Test
 - pwsh: dotnet cake --target=Pack
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -27,7 +27,7 @@ build_script:
 - pwsh: dotnet tool install --global Cake.Tool
 - pwsh: dotnet cake --target=Build
 - pwsh: dotnet cake --target=InstallDeveloperCertificate
-- pwsh: dotnet cake --target=Test
+- pwsh: dotnet cake --target=Test --verbosity=Diagnostic
 - pwsh: dotnet cake --target=Pack
 
 test: off

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -47,7 +47,7 @@ stages:
     - script: 'dotnet cake --target=InstallDeveloperCertificate'
       displayName: 'Dotnet Cake InstallDeveloperCertificate'
       failOnStderr: true
-    - script: 'dotnet cake --target=Test'
+    - script: 'dotnet cake --target=Test --verbosity=Diagnostic'
       displayName: 'Dotnet Cake Test'
       failOnStderr: true
     - script: 'dotnet cake --target=Pack'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -31,7 +31,7 @@ stages:
           vmImageName: windows-latest
     pool:
       vmImage: $(vmImageName)
-    timeoutInMinutes: 10
+    timeoutInMinutes: 20
     steps:
     - task: UseDotNet@2
       displayName: 'Install .NET Core SDK'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -46,7 +46,7 @@ stages:
       failOnStderr: true
     - script: 'dotnet cake --target=InstallDeveloperCertificate'
       displayName: 'Dotnet Cake InstallDeveloperCertificate'
-      failOnStderr: true
+      failOnStderr: false
     - script: 'dotnet cake --target=Test'
       displayName: 'Dotnet Cake Test'
       failOnStderr: true

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -44,6 +44,9 @@ stages:
     - script: 'dotnet cake --target=Build'
       displayName: 'Dotnet Cake Build'
       failOnStderr: true
+    - script: 'dotnet cake --target=InstallDeveloperCertificate'
+      displayName: 'Dotnet Cake InstallDeveloperCertificate'
+      failOnStderr: true
     - script: 'dotnet cake --target=Test'
       displayName: 'Dotnet Cake Test'
       failOnStderr: true

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -46,7 +46,7 @@ stages:
       failOnStderr: true
     - script: 'dotnet cake --target=InstallDeveloperCertificate'
       displayName: 'Dotnet Cake InstallDeveloperCertificate'
-      failOnStderr: false
+      failOnStderr: true
     - script: 'dotnet cake --target=Test'
       displayName: 'Dotnet Cake Test'
       failOnStderr: true

--- a/build.cake
+++ b/build.cake
@@ -65,7 +65,7 @@ Task("InstallDeveloperCertificate")
         Information($"Dotnet Developer Certificate saved");
 
         var certificate = new X509Certificate2(certificateFilePath);
-        using (var store = new X509Store(StoreName.Root, StoreLocation.LocalMachine))
+        using (var store = new X509Store(StoreName.Root, StoreLocation.CurrentUser))
         {
             store.Open(OpenFlags.ReadWrite);
             store.Add(certificate);

--- a/build.cake
+++ b/build.cake
@@ -125,19 +125,6 @@ Task("Default")
 
 RunTarget(target);
 
-Teardown(context =>
-{
-    // CI is failing to exit the cake script.
-    if (isRunningOnCI)
-    {
-        foreach (var process in System.Diagnostics.Process.GetProcessesByName("dotnet"))
-        {
-            Information("Killing dotnet process");
-            process.Kill();
-        }
-    }
-});
-
 public void StartProcess(string processName, ProcessArgumentBuilder builder)
 {
     var command = $"{processName} {builder.RenderSafe()}";

--- a/build.cake
+++ b/build.cake
@@ -102,13 +102,13 @@ Task("Test")
         }
 
         // CI is failing to exit the cake script.
-        if (isRunningOnCI)
-        {
-            foreach (var process in Process.GetProcessesByName("dotnet"))
-            {
-                process.Kill();
-            }
-        }
+        // if (isRunningOnCI)
+        // {
+        //     foreach (var process in Process.GetProcessesByName("dotnet"))
+        //     {
+        //         process.Kill();
+        //     }
+        // }
     });
 
 Task("Pack")

--- a/build.cake
+++ b/build.cake
@@ -23,7 +23,7 @@ var artifactsDirectory = Directory("./Artifacts");
 var templatePackProject = Directory("./Source/*.csproj");
 var versionSuffix = string.IsNullOrEmpty(preReleaseSuffix) ? null : preReleaseSuffix + "-" + buildNumber.ToString("D4");
 var isRunningOnCI = TFBuild.IsRunningOnAzurePipelinesHosted || AppVeyor.IsRunningOnAppVeyor;
-var isDotnetRunEnabled = AppVeyor.IsRunningOnAppVeyor || (TFBuild.IsRunningOnAzurePipelinesHosted && IsRunningOnWindows());
+var isDotnetRunEnabled = !isRunningOnCI || (isRunningOnCI && IsRunningOnWindows());
 
 Task("Clean")
     .Does(() =>
@@ -84,7 +84,6 @@ Task("InstallDeveloperCertificate")
     });
 
 Task("Test")
-    .IsDependentOn("InstallDeveloperCertificate")
     .Does(() =>
     {
         foreach(var project in GetFiles("./Tests/**/*.csproj"))

--- a/build.cake
+++ b/build.cake
@@ -79,7 +79,7 @@ Task("InstallDeveloperCertificate")
         }
         else
         {
-            Information("This CI server does not support installing certificates")
+            Information("This CI server does not support installing certificates");
         }
     });
 

--- a/build.cake
+++ b/build.cake
@@ -22,6 +22,7 @@ var artifactsDirectory = Directory("./Artifacts");
 var templatePackProject = Directory("./Source/*.csproj");
 var versionSuffix = string.IsNullOrEmpty(preReleaseSuffix) ? null : preReleaseSuffix + "-" + buildNumber.ToString("D4");
 var isRunningOnCI = TFBuild.IsRunningOnAzurePipelinesHosted || AppVeyor.IsRunningOnAppVeyor;
+var isDotnetRunEnabled = !isRunningOnCI || (isRunningOnCI && IsRunningOnWindows());
 
 Task("Clean")
     .Does(() =>
@@ -52,7 +53,7 @@ Task("Restore")
     });
 
 Task("InstallDeveloperCertificate")
-    .WithCriteria(x =>  isRunningOnCI)
+    .WithCriteria(x =>  isDotnetRunEnabled)
     .Does(() =>
     {
         var certificateFilePath = System.IO.Path.ChangeExtension(System.IO.Path.GetTempFileName(), ".pfx");
@@ -85,7 +86,7 @@ Task("Test")
                 new DotNetCoreTestSettings()
                 {
                     Configuration = configuration,
-                    Filter = isRunningOnCI && !IsRunningOnWindows() ? "IsUsingDotnetRun=false" : null,
+                    Filter = isDotnetRunEnabled ? null : "IsUsingDotnetRun=false",
                     Logger = $"trx;LogFileName={project.GetFilenameWithoutExtension()}.trx",
                     NoBuild = true,
                     NoRestore = true,

--- a/build.cake
+++ b/build.cake
@@ -99,6 +99,7 @@ Task("Test")
                     NoRestore = true,
                     ResultsDirectory = artifactsDirectory
                 });
+            Information($"Completed {project.GetFilenameWithoutExtension()} tests");
         }
     });
 
@@ -131,6 +132,7 @@ Teardown(context =>
     {
         foreach (var process in System.Diagnostics.Process.GetProcessesByName("dotnet"))
         {
+            Information("Killing dotnet process");
             process.Kill();
         }
     }

--- a/build.cake
+++ b/build.cake
@@ -100,15 +100,6 @@ Task("Test")
                     ResultsDirectory = artifactsDirectory
                 });
         }
-
-        // CI is failing to exit the cake script.
-        // if (isRunningOnCI)
-        // {
-        //     foreach (var process in Process.GetProcessesByName("dotnet"))
-        //     {
-        //         process.Kill();
-        //     }
-        // }
     });
 
 Task("Pack")
@@ -132,6 +123,18 @@ Task("Default")
     .IsDependentOn("Pack");
 
 RunTarget(target);
+
+Teardown(context =>
+{
+    // CI is failing to exit the cake script.
+    if (isRunningOnCI)
+    {
+        foreach (var process in System.Diagnostics.Process.GetProcessesByName("dotnet"))
+        {
+            process.Kill();
+        }
+    }
+});
 
 public void StartProcess(string processName, ProcessArgumentBuilder builder)
 {

--- a/build.cake
+++ b/build.cake
@@ -119,8 +119,8 @@ RunTarget(target);
 
 Teardown(context =>
 {
-    // Appveyor is failing to exit the cake script.
-    if (AppVeyor.IsRunningOnAppVeyor)
+    // CI is failing to exit the cake script.
+    if (isRunningOnCI)
     {
         foreach (var process in System.Diagnostics.Process.GetProcessesByName("dotnet"))
         {


### PR DESCRIPTION
- Installs an ASP.NET Core developer certificate as a Cake task, so that we can run `dotnet run` against projects created from a template. This fails on Mac because Azure Pipelines because we don't have admin permissions and fails on Ubuntu because the .NET API to install certificates doesn't exist.
- Enables running `dotnet run` based unit tests on Windows but not Linux and Mac.
- Fix `dotnet run` command that was not cleaning up child processes when we were done with it and wanted to shut down the app.