### PR TITLE
Add public signing option

### DIFF
--- a/Docs/NuGet.md
+++ b/Docs/NuGet.md
@@ -15,6 +15,7 @@ The NuGet package project template uses `dotnet new` to enable you to turn featu
 - **Contact** - The contact details to use if someone wants to contact you about a security vulnerability or code of conduct issues.
 - **DotnetCore** - Sets .NET Core as one of the target frameworks.
 - **DotnetFramework** - Sets .NET Framework as one of the target frameworks.
+- **PublicSign** - Signs the NuGet package with a public key.
 - **ReadMe** - Add a README.md markdown file describing the project.
 - **EditorConfig** - Add a .editorconfig file to set a fixed code style.
 - **License** - The legal license applied to the source code in this project.

--- a/Source/ApiTemplate/.template.config/template.json
+++ b/Source/ApiTemplate/.template.config/template.json
@@ -109,6 +109,13 @@
             "Source/ApiTemplate/wwwroot/humans.txt"
           ]
         },
+        // HealthCheck
+        {
+          "condition": "(!HealthCheck)",
+          "exclude": [
+            "Tests/ApiTemplate.IntegrationTest/HealthCheckTest.cs"
+          ]
+        },
         // IntegrationTest
         {
           "condition": "(!IntegrationTest)",

--- a/Source/GraphQLTemplate/.template.config/template.json
+++ b/Source/GraphQLTemplate/.template.config/template.json
@@ -115,6 +115,13 @@
             "Source/GraphQLTemplate/wwwroot/humans.txt"
           ]
         },
+        // HealthCheck
+        {
+          "condition": "(!HealthCheck)",
+          "exclude": [
+            "Tests/GraphQLTemplate.IntegrationTest/HealthCheckTest.cs"
+          ]
+        },
         // IntegrationTest
         {
           "condition": "(!IntegrationTest)",

--- a/Source/NuGetTemplate/.template.config/dotnetcli.host.json
+++ b/Source/NuGetTemplate/.template.config/dotnetcli.host.json
@@ -37,6 +37,9 @@
     "DotnetFramework": {
       "longName": "dotnet-framework"
     },
+    "PublicSign": {
+      "longName": "public-sign"
+    },
     "ReadMe": {
       "longName": "readme"
     },

--- a/Source/NuGetTemplate/.template.config/template.json
+++ b/Source/NuGetTemplate/.template.config/template.json
@@ -170,8 +170,15 @@
     "DotnetFramework": {
       "type": "parameter",
       "datatype": "bool",
-      "defaultValue": "true",
+      "defaultValue": "false",
       "description": "Sets .NET Framework as one of the target frameworks."
+    },
+    // PublicSign
+    "PublicSign": {
+      "type": "parameter",
+      "datatype": "bool",
+      "defaultValue": "true",
+      "description": "Signs the NuGet package with a public key."
     },
     // ReadMe
     "ReadMe": {

--- a/Source/NuGetTemplate/Source/NuGetTemplate/NuGetTemplate.csproj
+++ b/Source/NuGetTemplate/Source/NuGetTemplate/NuGetTemplate.csproj
@@ -5,10 +5,11 @@
     <DefineConstants>$(DefineConstants);</DefineConstants>
     <!-- Workaround to build this project: https://github.com/dotnet/templating/issues/1438 -->
     <DotnetCore>true</DotnetCore>
-    <DotnetFramework>true</DotnetFramework>
+    <DotnetFramework>false</DotnetFramework>
     <MIT>true</MIT>
     <StyleCop>true</StyleCop>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+    <PublicSign>true</PublicSign>
   </PropertyGroup>
   <!--#endif-->
 
@@ -38,7 +39,7 @@
     <PackageReleaseNotes>https://github.com/GITHUB-USERNAME/GITHUB-PROJECT/releases</PackageReleaseNotes>
   </PropertyGroup>
 
-  <PropertyGroup Label="Signing">
+  <PropertyGroup Label="Signing" Condition="'$(PublicSign)' == 'true'">
     <SignAssembly>true</SignAssembly>
     <AssemblyOriginatorKeyFile>../../Key.snk</AssemblyOriginatorKeyFile>
     <PublicSign>true</PublicSign>

--- a/Source/NuGetTemplate/Tests/NuGetTemplate.Test/NuGetTemplate.Test.csproj
+++ b/Source/NuGetTemplate/Tests/NuGetTemplate.Test/NuGetTemplate.Test.csproj
@@ -5,7 +5,7 @@
     <DefineConstants>$(DefineConstants);</DefineConstants>
     <!-- Workaround to build this project: https://github.com/dotnet/templating/issues/1438 -->
     <DotnetCore>true</DotnetCore>
-    <DotnetFramework>true</DotnetFramework>
+    <DotnetFramework>false</DotnetFramework>
     <StyleCop>true</StyleCop>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>

--- a/Tests/Boxed.Templates.FunctionalTest/ApiTemplateTest.cs
+++ b/Tests/Boxed.Templates.FunctionalTest/ApiTemplateTest.cs
@@ -36,7 +36,7 @@ namespace Boxed.Templates.FunctionalTest
         [InlineData("ApiNoHostFiltering", "host-filtering=false")]
         [InlineData("ApiNoFwdHdrsOrHostFilter", "forwarded-headers=false", "host-filtering=false")]
         [InlineData("ApiStyleCop", "style-cop=true")]
-        public async Task RestoreAndBuild_ApiDefaults_SuccessfulAsync(string name, params string[] arguments)
+        public async Task RestoreBuildTest_ApiDefaults_SuccessfulAsync(string name, params string[] arguments)
         {
             await InstallTemplateAsync().ConfigureAwait(false);
             using (var tempDirectory = TempDirectory.NewTempDirectory())
@@ -47,12 +47,13 @@ namespace Boxed.Templates.FunctionalTest
                 var project = await tempDirectory.DotnetNewAsync(TemplateName, name, dictionary).ConfigureAwait(false);
                 await project.DotnetRestoreAsync().ConfigureAwait(false);
                 await project.DotnetBuildAsync().ConfigureAwait(false);
+                await project.DotnetTestAsync().ConfigureAwait(false);
             }
         }
 
         [Fact]
         [Trait("IsUsingDotnetRun", "true")]
-        public async Task Run_ApiDefaults_SuccessfulAsync()
+        public async Task RestoreBuildTestRun_ApiDefaults_SuccessfulAsync()
         {
             await InstallTemplateAsync().ConfigureAwait(false);
             using (var tempDirectory = TempDirectory.NewTempDirectory())
@@ -60,6 +61,7 @@ namespace Boxed.Templates.FunctionalTest
                 var project = await tempDirectory.DotnetNewAsync(TemplateName, "ApiDefaults").ConfigureAwait(false);
                 await project.DotnetRestoreAsync().ConfigureAwait(false);
                 await project.DotnetBuildAsync().ConfigureAwait(false);
+                await project.DotnetTestAsync().ConfigureAwait(false);
                 await project
                     .DotnetRunAsync(
                         @"Source\ApiDefaults",
@@ -135,7 +137,7 @@ namespace Boxed.Templates.FunctionalTest
 
         [Fact]
         [Trait("IsUsingDotnetRun", "true")]
-        public async Task Run_HealthCheckFalse_SuccessfulAsync()
+        public async Task RestoreBuildTestRun_HealthCheckFalse_SuccessfulAsync()
         {
             await InstallTemplateAsync().ConfigureAwait(false);
             using (var tempDirectory = TempDirectory.NewTempDirectory())
@@ -151,6 +153,7 @@ namespace Boxed.Templates.FunctionalTest
                     .ConfigureAwait(false);
                 await project.DotnetRestoreAsync().ConfigureAwait(false);
                 await project.DotnetBuildAsync().ConfigureAwait(false);
+                await project.DotnetTestAsync().ConfigureAwait(false);
                 await project
                     .DotnetRunAsync(
                         @"Source\ApiHealthCheckFalse",
@@ -173,7 +176,7 @@ namespace Boxed.Templates.FunctionalTest
 
         [Fact]
         [Trait("IsUsingDotnetRun", "true")]
-        public async Task Run_HttpsEverywhereFalse_SuccessfulAsync()
+        public async Task RestoreBuildTestRun_HttpsEverywhereFalse_SuccessfulAsync()
         {
             await InstallTemplateAsync().ConfigureAwait(false);
             using (var tempDirectory = TempDirectory.NewTempDirectory())
@@ -189,6 +192,7 @@ namespace Boxed.Templates.FunctionalTest
                     .ConfigureAwait(false);
                 await project.DotnetRestoreAsync().ConfigureAwait(false);
                 await project.DotnetBuildAsync().ConfigureAwait(false);
+                await project.DotnetTestAsync().ConfigureAwait(false);
                 await project
                     .DotnetRunAsync(
                         @"Source\ApiHttpsEverywhereFalse",
@@ -212,7 +216,7 @@ namespace Boxed.Templates.FunctionalTest
 
         [Fact]
         [Trait("IsUsingDotnetRun", "true")]
-        public async Task Run_SwaggerFalse_SuccessfulAsync()
+        public async Task RestoreBuildTestRun_SwaggerFalse_SuccessfulAsync()
         {
             await InstallTemplateAsync().ConfigureAwait(false);
             using (var tempDirectory = TempDirectory.NewTempDirectory())
@@ -228,6 +232,7 @@ namespace Boxed.Templates.FunctionalTest
                     .ConfigureAwait(false);
                 await project.DotnetRestoreAsync().ConfigureAwait(false);
                 await project.DotnetBuildAsync().ConfigureAwait(false);
+                await project.DotnetTestAsync().ConfigureAwait(false);
                 await project
                     .DotnetRunAsync(
                         @"Source\ApiSwaggerFalse",
@@ -244,7 +249,7 @@ namespace Boxed.Templates.FunctionalTest
         }
 
         [Fact]
-        public async Task Run_DockerFalse_SuccessfulAsync()
+        public async Task RestoreBuildTestRun_DockerFalse_SuccessfulAsync()
         {
             await InstallTemplateAsync().ConfigureAwait(false);
             using (var tempDirectory = TempDirectory.NewTempDirectory())
@@ -260,6 +265,7 @@ namespace Boxed.Templates.FunctionalTest
                     .ConfigureAwait(false);
                 await project.DotnetRestoreAsync().ConfigureAwait(false);
                 await project.DotnetBuildAsync().ConfigureAwait(false);
+                await project.DotnetTestAsync().ConfigureAwait(false);
 
                 var files = new DirectoryInfo(project.DirectoryPath).GetFiles("*.*", SearchOption.AllDirectories);
 

--- a/Tests/Boxed.Templates.FunctionalTest/Boxed.Templates.FunctionalTest.csproj
+++ b/Tests/Boxed.Templates.FunctionalTest/Boxed.Templates.FunctionalTest.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup Label="Package References">
-    <PackageReference Include="Boxed.DotnetNewTest" Version="3.2.3" />
+    <PackageReference Include="Boxed.DotnetNewTest" Version="3.3.0" />
     <PackageReference Include="coverlet.collector" PrivateAssets="All" Version="1.2.0">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/Tests/Boxed.Templates.FunctionalTest/GraphQLTemplateTest.cs
+++ b/Tests/Boxed.Templates.FunctionalTest/GraphQLTemplateTest.cs
@@ -35,7 +35,7 @@ namespace Boxed.Templates.FunctionalTest
         [InlineData("GraphQLTNoHostFiltering", "host-filtering=false")]
         [InlineData("GraphQLTNoFwdHdrsOrHostFilter", "forwarded-headers=false", "host-filtering=false")]
         [InlineData("GraphQLStyleCop", "style-cop=true")]
-        public async Task RestoreAndBuild_GraphQLDefaults_SuccessfulAsync(string name, params string[] arguments)
+        public async Task RestoreBuildTest_GraphQLDefaults_SuccessfulAsync(string name, params string[] arguments)
         {
             await InstallTemplateAsync().ConfigureAwait(false);
             using (var tempDirectory = TempDirectory.NewTempDirectory())
@@ -46,12 +46,13 @@ namespace Boxed.Templates.FunctionalTest
                 var project = await tempDirectory.DotnetNewAsync(TemplateName, name, dictionary).ConfigureAwait(false);
                 await project.DotnetRestoreAsync().ConfigureAwait(false);
                 await project.DotnetBuildAsync().ConfigureAwait(false);
+                await project.DotnetTestAsync().ConfigureAwait(false);
             }
         }
 
         [Fact]
         [Trait("IsUsingDotnetRun", "true")]
-        public async Task Run_GraphQLDefaults_SuccessfulAsync()
+        public async Task RestoreBuildTestRun_GraphQLDefaults_SuccessfulAsync()
         {
             await InstallTemplateAsync().ConfigureAwait(false);
             using (var tempDirectory = TempDirectory.NewTempDirectory())
@@ -59,6 +60,7 @@ namespace Boxed.Templates.FunctionalTest
                 var project = await tempDirectory.DotnetNewAsync(TemplateName, "GraphQLTDefaults").ConfigureAwait(false);
                 await project.DotnetRestoreAsync().ConfigureAwait(false);
                 await project.DotnetBuildAsync().ConfigureAwait(false);
+                await project.DotnetTestAsync().ConfigureAwait(false);
                 await project
                     .DotnetRunAsync(
                         @"Source\GraphQLTDefaults",
@@ -106,7 +108,7 @@ namespace Boxed.Templates.FunctionalTest
 
         [Fact]
         [Trait("IsUsingDotnetRun", "true")]
-        public async Task Run_HealthCheckFalse_SuccessfulAsync()
+        public async Task RestoreBuildTestRun_HealthCheckFalse_SuccessfulAsync()
         {
             await InstallTemplateAsync().ConfigureAwait(false);
             using (var tempDirectory = TempDirectory.NewTempDirectory())
@@ -122,6 +124,7 @@ namespace Boxed.Templates.FunctionalTest
                     .ConfigureAwait(false);
                 await project.DotnetRestoreAsync().ConfigureAwait(false);
                 await project.DotnetBuildAsync().ConfigureAwait(false);
+                await project.DotnetTestAsync().ConfigureAwait(false);
                 await project
                     .DotnetRunAsync(
                         @"Source\GraphQLTHealthCheckFalse",
@@ -144,7 +147,7 @@ namespace Boxed.Templates.FunctionalTest
 
         [Fact]
         [Trait("IsUsingDotnetRun", "true")]
-        public async Task Run_QueryGraphQlIntrospection_ReturnsResultsAsync()
+        public async Task RestoreBuildTestRun_QueryGraphQlIntrospection_ReturnsResultsAsync()
         {
             await InstallTemplateAsync().ConfigureAwait(false);
             using (var tempDirectory = TempDirectory.NewTempDirectory())
@@ -152,6 +155,7 @@ namespace Boxed.Templates.FunctionalTest
                 var project = await tempDirectory.DotnetNewAsync(TemplateName, "GraphQLTDefaults").ConfigureAwait(false);
                 await project.DotnetRestoreAsync().ConfigureAwait(false);
                 await project.DotnetBuildAsync().ConfigureAwait(false);
+                await project.DotnetTestAsync().ConfigureAwait(false);
                 await project
                     .DotnetRunAsync(
                         @"Source\GraphQLTDefaults",
@@ -173,7 +177,7 @@ namespace Boxed.Templates.FunctionalTest
 
         [Fact]
         [Trait("IsUsingDotnetRun", "true")]
-        public async Task Run_HttpsEverywhereFalse_SuccessfulAsync()
+        public async Task RestoreBuildTestRun_HttpsEverywhereFalse_SuccessfulAsync()
         {
             await InstallTemplateAsync().ConfigureAwait(false);
             using (var tempDirectory = TempDirectory.NewTempDirectory())
@@ -189,6 +193,7 @@ namespace Boxed.Templates.FunctionalTest
                     .ConfigureAwait(false);
                 await project.DotnetRestoreAsync().ConfigureAwait(false);
                 await project.DotnetBuildAsync().ConfigureAwait(false);
+                await project.DotnetTestAsync().ConfigureAwait(false);
                 await project
                     .DotnetRunAsync(
                         @"Source\GraphQLTHttpsEverywhereFalse",
@@ -212,7 +217,7 @@ namespace Boxed.Templates.FunctionalTest
 
         [Fact]
         [Trait("IsUsingDotnetRun", "true")]
-        public async Task Run_AuthorizationTrue_Returns400BadRequestAsync()
+        public async Task RestoreBuildTestRun_AuthorizationTrue_Returns400BadRequestAsync()
         {
             await InstallTemplateAsync().ConfigureAwait(false);
             using (var tempDirectory = TempDirectory.NewTempDirectory())
@@ -228,6 +233,7 @@ namespace Boxed.Templates.FunctionalTest
                     .ConfigureAwait(false);
                 await project.DotnetRestoreAsync().ConfigureAwait(false);
                 await project.DotnetBuildAsync().ConfigureAwait(false);
+                await project.DotnetTestAsync().ConfigureAwait(false);
                 await project
                     .DotnetRunAsync(
                         @"Source\GraphQLTAuthorizationTrue",
@@ -254,7 +260,7 @@ namespace Boxed.Templates.FunctionalTest
 
         [Fact]
         [Trait("IsUsingDotnetRun", "true")]
-        public async Task Run_AuthorizationFalse_DateOfBirthReturnedSuccessfullyAsync()
+        public async Task RestoreBuildTestRun_AuthorizationFalse_DateOfBirthReturnedSuccessfullyAsync()
         {
             await InstallTemplateAsync().ConfigureAwait(false);
             using (var tempDirectory = TempDirectory.NewTempDirectory())
@@ -270,6 +276,7 @@ namespace Boxed.Templates.FunctionalTest
                     .ConfigureAwait(false);
                 await project.DotnetRestoreAsync().ConfigureAwait(false);
                 await project.DotnetBuildAsync().ConfigureAwait(false);
+                await project.DotnetTestAsync().ConfigureAwait(false);
                 await project
                     .DotnetRunAsync(
                         @"Source\GraphQLTAuthorizationFalse",
@@ -287,7 +294,7 @@ namespace Boxed.Templates.FunctionalTest
         }
 
         [Fact]
-        public async Task Run_DockerFalse_SuccessfulAsync()
+        public async Task RestoreBuildTestRun_DockerFalse_SuccessfulAsync()
         {
             await InstallTemplateAsync().ConfigureAwait(false);
             using (var tempDirectory = TempDirectory.NewTempDirectory())
@@ -303,6 +310,7 @@ namespace Boxed.Templates.FunctionalTest
                     .ConfigureAwait(false);
                 await project.DotnetRestoreAsync().ConfigureAwait(false);
                 await project.DotnetBuildAsync().ConfigureAwait(false);
+                await project.DotnetTestAsync().ConfigureAwait(false);
 
                 var files = new DirectoryInfo(project.DirectoryPath).GetFiles("*.*", SearchOption.AllDirectories);
 

--- a/Tests/Boxed.Templates.FunctionalTest/NuGetTemplateTest.cs
+++ b/Tests/Boxed.Templates.FunctionalTest/NuGetTemplateTest.cs
@@ -1,6 +1,7 @@
 namespace Boxed.Templates.FunctionalTest
 {
     using System;
+    using System.Collections.Generic;
     using System.IO;
     using System.Linq;
     using System.Threading.Tasks;
@@ -27,9 +28,9 @@ namespace Boxed.Templates.FunctionalTest
         [Trait("IsUsingDotnetRun", "false")]
         [InlineData("NuGetDefaults")]
         [InlineData("NuGetStyleCop", "style-cop=true")]
-        [InlineData("NuGetNoDotnetCore", "dotnet-core=false")]
-        [InlineData("NuGetNoDotnetFramework", "dotnet-framework=false")]
-        public async Task RestoreAndBuild_NuGetDefaults_SuccessfulAsync(string name, params string[] arguments)
+        [InlineData("NuGetNoDotnetFramework", "dotnet-framework=true")]
+        [InlineData("NuGetNoDotnetCore", "dotnet-core=false", "dotnet-framework=true")]
+        public async Task RestoreBuildTestCake_NuGetDefaults_SuccessfulAsync(string name, params string[] arguments)
         {
             await InstallTemplateAsync().ConfigureAwait(false);
             using (var tempDirectory = TempDirectory.NewTempDirectory())
@@ -40,6 +41,16 @@ namespace Boxed.Templates.FunctionalTest
                 var project = await tempDirectory.DotnetNewAsync(TemplateName, name, dictionary).ConfigureAwait(false);
                 await project.DotnetRestoreAsync().ConfigureAwait(false);
                 await project.DotnetBuildAsync().ConfigureAwait(false);
+
+                // There is currently an issue with enabling .NET Framework and PublicSign.
+                // https://github.com/dotnet/sdk/issues/10597
+                // https://stackoverflow.com/questions/60058571
+                if (!arguments.Contains("dotnet-framework=true"))
+                {
+                    await project.DotnetTestAsync().ConfigureAwait(false);
+                    await project.DotnetToolRestoreAsync().ConfigureAwait(false);
+                    await project.DotnetCakeAsync().ConfigureAwait(false);
+                }
             }
         }
 
@@ -47,7 +58,7 @@ namespace Boxed.Templates.FunctionalTest
         [InlineData("NuGetNoAppVeyor", "appveyor.yml", "AppVeyor", "appveyor=false")]
         [InlineData("NuGetNoAzurePipelines", "azure-pipelines.yml", "AzurePipelines", "azure-pipelines=false")]
         [InlineData("NuGetNoGitHubActions", @"/.github/workflows/build.yml", "GitHubActions", "github-actions=false")]
-        public async Task RestoreAndBuild_NoContinuousIntegration_SuccessfulAsync(
+        public async Task RestoreBuildTestCake_NoContinuousIntegration_SuccessfulAsync(
             string name,
             string relativeFilePath,
             string cakeContent,
@@ -62,10 +73,43 @@ namespace Boxed.Templates.FunctionalTest
                 var project = await tempDirectory.DotnetNewAsync(TemplateName, name, dictionary).ConfigureAwait(false);
                 await project.DotnetRestoreAsync().ConfigureAwait(false);
                 await project.DotnetBuildAsync().ConfigureAwait(false);
+                await project.DotnetTestAsync().ConfigureAwait(false);
+                await project.DotnetToolRestoreAsync().ConfigureAwait(false);
+                await project.DotnetCakeAsync().ConfigureAwait(false);
 
                 Assert.False(File.Exists(Path.Combine(project.DirectoryPath, relativeFilePath)));
                 var cake = await File.ReadAllTextAsync(Path.Combine(project.DirectoryPath, "build.cake")).ConfigureAwait(false);
                 Assert.DoesNotContain(cakeContent, cake, StringComparison.Ordinal);
+            }
+        }
+
+        [Fact]
+        [Trait("IsUsingDotnetRun", "false")]
+        public async Task RestoreBuildTestCake_PublicSignFalse_SuccessfulAsync()
+        {
+            await InstallTemplateAsync().ConfigureAwait(false);
+            using (var tempDirectory = TempDirectory.NewTempDirectory())
+            {
+                var project = await tempDirectory
+                    .DotnetNewAsync(
+                        TemplateName,
+                        "NuGetPublicSignFalse",
+                        new Dictionary<string, string>()
+                        {
+                            { "public-sign", "false" },
+                        })
+                    .ConfigureAwait(false);
+                await project.DotnetRestoreAsync().ConfigureAwait(false);
+                await project.DotnetBuildAsync().ConfigureAwait(false);
+                await project.DotnetTestAsync().ConfigureAwait(false);
+                await project.DotnetToolRestoreAsync().ConfigureAwait(false);
+                await project.DotnetCakeAsync().ConfigureAwait(false);
+
+                var files = new DirectoryInfo(project.DirectoryPath).GetFiles("*.*", SearchOption.AllDirectories);
+
+                var csprojFile = files.Single(x => x.Name == "NuGetPublicSignFalse.csproj");
+                var csproj = File.ReadAllText(csprojFile.FullName);
+                Assert.DoesNotContain("PublicSign", csproj, StringComparison.Ordinal);
             }
         }
 

--- a/Tests/Boxed.Templates.FunctionalTest/OrleansTemplateTest.cs
+++ b/Tests/Boxed.Templates.FunctionalTest/OrleansTemplateTest.cs
@@ -27,7 +27,7 @@ namespace Boxed.Templates.FunctionalTest
         [InlineData("OrleansDefaults")]
         [InlineData("OrleansStyleCop", "style-cop=true")]
         [InlineData("OrleansNoHealthCheck", "health-check=false")]
-        public async Task RestoreAndBuild_OrleansDefaults_SuccessfulAsync(string name, params string[] arguments)
+        public async Task RestoreBuild_OrleansDefaults_SuccessfulAsync(string name, params string[] arguments)
         {
             await InstallTemplateAsync().ConfigureAwait(false);
             using (var tempDirectory = TempDirectory.NewTempDirectory())


### PR DESCRIPTION
- Add PublicSign option to NuGet template and disable .NET Framework by default due to an issue.
- Run dotnet test in functional tests.
- Fix health-check-false option.