### PR TITLE
Remove redundant Serilog packages.

### DIFF
--- a/Source/ApiTemplate/Source/ApiTemplate/ApiTemplate.csproj
+++ b/Source/ApiTemplate/Source/ApiTemplate/ApiTemplate.csproj
@@ -69,10 +69,7 @@
     <PackageReference Include="Serilog.Enrichers.Process" Version="2.0.1" />
     <PackageReference Include="Serilog.Enrichers.Thread" Version="3.1.0" />
     <PackageReference Include="Serilog.Exceptions" Version="5.4.0" />
-    <PackageReference Include="Serilog.Settings.Configuration" Version="3.1.0" />
     <PackageReference Include="Serilog.Sinks.ApplicationInsights" Version="3.1.0" Condition="'$(ApplicationInsights)' == 'true'" />
-    <PackageReference Include="Serilog.Sinks.Console" Version="3.1.1" />
-    <PackageReference Include="Serilog.Sinks.Debug" Version="1.0.1" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="5.0.0" Condition="'$(Swagger)' == 'true'" />
     <PackageReference Include="Swashbuckle.AspNetCore.Annotations" Version="5.0.0" Condition="'$(Swagger)' == 'true'" />
   </ItemGroup>

--- a/Source/GraphQLTemplate/Source/GraphQLTemplate/GraphQLTemplate.csproj
+++ b/Source/GraphQLTemplate/Source/GraphQLTemplate/GraphQLTemplate.csproj
@@ -66,10 +66,7 @@
     <PackageReference Include="Serilog.Enrichers.Process" Version="2.0.1" />
     <PackageReference Include="Serilog.Enrichers.Thread" Version="3.1.0" />
     <PackageReference Include="Serilog.Exceptions" Version="5.4.0" />
-    <PackageReference Include="Serilog.Settings.Configuration" Version="3.1.0" />
     <PackageReference Include="Serilog.Sinks.ApplicationInsights" Version="3.1.0" Condition="'$(ApplicationInsights)' == 'true'" />
-    <PackageReference Include="Serilog.Sinks.Console" Version="3.1.1" />
-    <PackageReference Include="Serilog.Sinks.Debug" Version="1.0.1" />
   </ItemGroup>
 
   <ItemGroup Label="Analyzer Package References">

--- a/Source/OrleansTemplate/Source/OrleansTemplate.Server/OrleansTemplate.Server.csproj
+++ b/Source/OrleansTemplate/Source/OrleansTemplate.Server/OrleansTemplate.Server.csproj
@@ -59,11 +59,7 @@
     <PackageReference Include="Serilog.Enrichers.Process" Version="2.0.1" />
     <PackageReference Include="Serilog.Enrichers.Thread" Version="3.1.0" />
     <PackageReference Include="Serilog.Exceptions" Version="5.4.0" />
-    <PackageReference Include="Serilog.Extensions.Hosting" Version="3.0.0" />
-    <PackageReference Include="Serilog.Settings.Configuration" Version="3.1.0" />
     <PackageReference Include="Serilog.Sinks.ApplicationInsights" Version="3.1.0" Condition="'$(ApplicationInsights)' == 'true'" />
-    <PackageReference Include="Serilog.Sinks.Console" Version="3.1.1" />
-    <PackageReference Include="Serilog.Sinks.Debug" Version="1.0.1" />
   </ItemGroup>
 
   <ItemGroup Label="Analyzer Package References">


### PR DESCRIPTION
Serilog.AspNetCore already includes the following packages we use:
- Serilog.Settings.Configuration
- Serilog.Sinks.Console
- Serilog.Sinks.Debug
- Serilog.Extensions.Hosting

<!--
Thank you good citizen for your hard work!

Please read the contributing guide before raising a pull request.
https://github.com/Dotnet-Boxed/Templates/blob/master/.github/CONTRIBUTING.md
-->
