### PR TITLE
Fix the templating in .editorconfig files

### DIFF
--- a/Source/ApiTemplate/.editorconfig
+++ b/Source/ApiTemplate/.editorconfig
@@ -387,7 +387,7 @@ dotnet_naming_rule.parameters_rule.symbols              = parameters_group
 dotnet_naming_rule.parameters_rule.style                = camel_case_style
 dotnet_naming_rule.parameters_rule.severity             = warning
 
-##if (StyleCop)
+#if (StyleCop)
 ##########################################
 # StyleCop
 ##########################################
@@ -434,7 +434,7 @@ dotnet_diagnostic.SA1629.severity = none
 # https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1633.md
 dotnet_diagnostic.SA1633.severity = none
 
-##endif
+#endif
 ##########################################
 # License
 ##########################################

--- a/Source/ApiTemplate/.template.config/template.json
+++ b/Source/ApiTemplate/.template.config/template.json
@@ -491,6 +491,80 @@
       "defaultValue": "false"
     }
   },
+  "SpecialCustomOperations": {
+    "**/.editorconfig": {
+      "operations": [
+        {
+          "type": "conditional",
+          "configuration": {
+            "if": [ "#if" ],
+            "else": [ "#else" ],
+            "elseif": [ "#elseif" ],
+            "endif": [ "#endif" ],
+            "actionableIf": [ "##if" ],
+            "actionableElse": [ "##else" ],
+            "actionableElseif": [ "##elseif" ],
+            "actions": [ "uncomment", "reduceComment" ],
+            "trim": "true",
+            "wholeLine": "true",
+            "evaluator": "C++"
+          }
+        },
+        {
+          "type": "replacement",
+          "configuration": {
+            "original": "#",
+            "replacement": "",
+            "id": "uncomment"
+          }
+        },
+        {
+          "type": "replacement",
+          "configuration": {
+            "original": "##",
+            "replacement": "#",
+            "id": "reduceComment"
+          }
+        }
+      ]
+    },
+    "**/Dockerfile": {
+      "operations": [
+        {
+          "type": "conditional",
+          "configuration": {
+            "if": [ "#if" ],
+            "else": [ "#else" ],
+            "elseif": [ "#elseif" ],
+            "endif": [ "#endif" ],
+            "actionableIf": [ "##if" ],
+            "actionableElse": [ "##else" ],
+            "actionableElseif": [ "##elseif" ],
+            "actions": [ "uncomment", "reduceComment" ],
+            "trim": "true",
+            "wholeLine": "true",
+            "evaluator": "C++"
+          }
+        },
+        {
+          "type": "replacement",
+          "configuration": {
+            "original": "#",
+            "replacement": "",
+            "id": "uncomment"
+          }
+        },
+        {
+          "type": "replacement",
+          "configuration": {
+            "original": "##",
+            "replacement": "#",
+            "id": "reduceComment"
+          }
+        }
+      ]
+    }
+  },
   "postActions": [
     {
       "actionId": "210D431B-A78B-4D2F-B762-4ED3E3EA9025",

--- a/Source/ApiTemplate/Source/ApiTemplate/Dockerfile
+++ b/Source/ApiTemplate/Source/ApiTemplate/Dockerfile
@@ -36,10 +36,10 @@ RUN apk add --no-cache \
 # Install time zone database to enable use of System.TimeZoneInfo
     tzdata
 WORKDIR /app
-//#if (HttpsEverywhere)
+#if (HttpsEverywhere)
 EXPOSE 80 443
-//#else
-EXPOSE 80
-//#endif
+##else
+#EXPOSE 80
+#endif
 COPY --from=sdk /app .
 ENTRYPOINT ["dotnet", "ApiTemplate.dll"]

--- a/Source/GraphQLTemplate/.editorconfig
+++ b/Source/GraphQLTemplate/.editorconfig
@@ -387,7 +387,7 @@ dotnet_naming_rule.parameters_rule.symbols              = parameters_group
 dotnet_naming_rule.parameters_rule.style                = camel_case_style
 dotnet_naming_rule.parameters_rule.severity             = warning
 
-##if (StyleCop)
+#if (StyleCop)
 ##########################################
 # StyleCop
 ##########################################
@@ -424,7 +424,7 @@ dotnet_diagnostic.SA1602.severity = none
 # https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1633.md
 dotnet_diagnostic.SA1633.severity = none
 
-##endif
+#endif
 ##########################################
 # License
 ##########################################

--- a/Source/GraphQLTemplate/.template.config/template.json
+++ b/Source/GraphQLTemplate/.template.config/template.json
@@ -468,6 +468,80 @@
       "defaultValue": "false"
     }
   },
+  "SpecialCustomOperations": {
+    "**/.editorconfig": {
+      "operations": [
+        {
+          "type": "conditional",
+          "configuration": {
+            "if": [ "#if" ],
+            "else": [ "#else" ],
+            "elseif": [ "#elseif" ],
+            "endif": [ "#endif" ],
+            "actionableIf": [ "##if" ],
+            "actionableElse": [ "##else" ],
+            "actionableElseif": [ "##elseif" ],
+            "actions": [ "uncomment", "reduceComment" ],
+            "trim": "true",
+            "wholeLine": "true",
+            "evaluator": "C++"
+          }
+        },
+        {
+          "type": "replacement",
+          "configuration": {
+            "original": "#",
+            "replacement": "",
+            "id": "uncomment"
+          }
+        },
+        {
+          "type": "replacement",
+          "configuration": {
+            "original": "##",
+            "replacement": "#",
+            "id": "reduceComment"
+          }
+        }
+      ]
+    },
+    "**/Dockerfile": {
+      "operations": [
+        {
+          "type": "conditional",
+          "configuration": {
+            "if": [ "#if" ],
+            "else": [ "#else" ],
+            "elseif": [ "#elseif" ],
+            "endif": [ "#endif" ],
+            "actionableIf": [ "##if" ],
+            "actionableElse": [ "##else" ],
+            "actionableElseif": [ "##elseif" ],
+            "actions": [ "uncomment", "reduceComment" ],
+            "trim": "true",
+            "wholeLine": "true",
+            "evaluator": "C++"
+          }
+        },
+        {
+          "type": "replacement",
+          "configuration": {
+            "original": "#",
+            "replacement": "",
+            "id": "uncomment"
+          }
+        },
+        {
+          "type": "replacement",
+          "configuration": {
+            "original": "##",
+            "replacement": "#",
+            "id": "reduceComment"
+          }
+        }
+      ]
+    }
+  },
   "postActions": [
     {
       "actionId": "210D431B-A78B-4D2F-B762-4ED3E3EA9025",

--- a/Source/GraphQLTemplate/Source/GraphQLTemplate/Dockerfile
+++ b/Source/GraphQLTemplate/Source/GraphQLTemplate/Dockerfile
@@ -36,10 +36,10 @@ RUN apk add --no-cache \
 # Install time zone database to enable use of System.TimeZoneInfo
     tzdata
 WORKDIR /app
-//#if (HttpsEverywhere)
+#if (HttpsEverywhere)
 EXPOSE 80 443
-//#else
-EXPOSE 80
-//#endif
+##else
+#EXPOSE 80
+#endif
 COPY --from=sdk /app .
 ENTRYPOINT ["dotnet", "GraphQLTemplate.dll"]

--- a/Source/NuGetTemplate/.editorconfig
+++ b/Source/NuGetTemplate/.editorconfig
@@ -387,7 +387,7 @@ dotnet_naming_rule.parameters_rule.symbols              = parameters_group
 dotnet_naming_rule.parameters_rule.style                = camel_case_style
 dotnet_naming_rule.parameters_rule.severity             = warning
 
-##if (StyleCop)
+#if (StyleCop)
 ##########################################
 # StyleCop
 ##########################################
@@ -398,7 +398,7 @@ dotnet_naming_rule.parameters_rule.severity             = warning
 # https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1633.md
 dotnet_diagnostic.SA1633.severity = none
 
-##endif
+#endif
 ##########################################
 # License
 ##########################################

--- a/Source/NuGetTemplate/.template.config/template.json
+++ b/Source/NuGetTemplate/.template.config/template.json
@@ -341,6 +341,44 @@
     //  "defaultValue": "false"
     //}
   },
+  "SpecialCustomOperations": {
+    "**/.editorconfig": {
+      "operations": [
+        {
+          "type": "conditional",
+          "configuration": {
+            "if": [ "#if" ],
+            "else": [ "#else" ],
+            "elseif": [ "#elseif" ],
+            "endif": [ "#endif" ],
+            "actionableIf": [ "##if" ],
+            "actionableElse": [ "##else" ],
+            "actionableElseif": [ "##elseif" ],
+            "actions": [ "uncomment", "reduceComment" ],
+            "trim": "true",
+            "wholeLine": "true",
+            "evaluator": "C++"
+          }
+        },
+        {
+          "type": "replacement",
+          "configuration": {
+            "original": "#",
+            "replacement": "",
+            "id": "uncomment"
+          }
+        },
+        {
+          "type": "replacement",
+          "configuration": {
+            "original": "##",
+            "replacement": "#",
+            "id": "reduceComment"
+          }
+        }
+      ]
+    }
+  },
   "postActions": [
     {
       "actionId": "210D431B-A78B-4D2F-B762-4ED3E3EA9025",

--- a/Source/OrleansTemplate/.editorconfig
+++ b/Source/OrleansTemplate/.editorconfig
@@ -387,7 +387,7 @@ dotnet_naming_rule.parameters_rule.symbols              = parameters_group
 dotnet_naming_rule.parameters_rule.style                = camel_case_style
 dotnet_naming_rule.parameters_rule.severity             = warning
 
-##if (StyleCop)
+#if (StyleCop)
 ##########################################
 # StyleCop
 ##########################################
@@ -424,7 +424,7 @@ dotnet_diagnostic.SA1602.severity = none
 # https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1633.md
 dotnet_diagnostic.SA1633.severity = none
 
-##endif
+#endif
 ##########################################
 # License
 ##########################################

--- a/Source/OrleansTemplate/.template.config/template.json
+++ b/Source/OrleansTemplate/.template.config/template.json
@@ -233,6 +233,80 @@
       "defaultValue": "false"
     }
   },
+  "SpecialCustomOperations": {
+    "**/.editorconfig": {
+      "operations": [
+        {
+          "type": "conditional",
+          "configuration": {
+            "if": [ "#if" ],
+            "else": [ "#else" ],
+            "elseif": [ "#elseif" ],
+            "endif": [ "#endif" ],
+            "actionableIf": [ "##if" ],
+            "actionableElse": [ "##else" ],
+            "actionableElseif": [ "##elseif" ],
+            "actions": [ "uncomment", "reduceComment" ],
+            "trim": "true",
+            "wholeLine": "true",
+            "evaluator": "C++"
+          }
+        },
+        {
+          "type": "replacement",
+          "configuration": {
+            "original": "#",
+            "replacement": "",
+            "id": "uncomment"
+          }
+        },
+        {
+          "type": "replacement",
+          "configuration": {
+            "original": "##",
+            "replacement": "#",
+            "id": "reduceComment"
+          }
+        }
+      ]
+    },
+    "**/Dockerfile": {
+      "operations": [
+        {
+          "type": "conditional",
+          "configuration": {
+            "if": [ "#if" ],
+            "else": [ "#else" ],
+            "elseif": [ "#elseif" ],
+            "endif": [ "#endif" ],
+            "actionableIf": [ "##if" ],
+            "actionableElse": [ "##else" ],
+            "actionableElseif": [ "##elseif" ],
+            "actions": [ "uncomment", "reduceComment" ],
+            "trim": "true",
+            "wholeLine": "true",
+            "evaluator": "C++"
+          }
+        },
+        {
+          "type": "replacement",
+          "configuration": {
+            "original": "#",
+            "replacement": "",
+            "id": "uncomment"
+          }
+        },
+        {
+          "type": "replacement",
+          "configuration": {
+            "original": "##",
+            "replacement": "#",
+            "id": "reduceComment"
+          }
+        }
+      ]
+    }
+  },
   "postActions": [
     {
       "actionId": "210D431B-A78B-4D2F-B762-4ED3E3EA9025",


### PR DESCRIPTION
- Fix the templating in `.editorconfig` files, so that StyleCop code is removed when it is turned off.
- Make templating in `Dockerfile` better, so the `Dockerfile` is runnable.