### PR TITLE
Use PrivateAssets='all'

### DIFF
--- a/Source/ApiTemplate/Directory.Build.props
+++ b/Source/ApiTemplate/Directory.Build.props
@@ -18,10 +18,10 @@
   </PropertyGroup>
 
   <ItemGroup Label="Package References">
-    <PackageReference Include="Microsoft.CodeAnalysis.FxCopAnalyzers" PrivateAssets="All" Version="3.0.0" />
-    <PackageReference Include="Microsoft.VisualStudio.Threading.Analyzers" PrivateAssets="All" Version="16.7.54" />
-    <PackageReference Include="MinVer" PrivateAssets="All" Version="2.3.0" />
-    <PackageReference Include="StyleCop.Analyzers" PrivateAssets="All" Version="1.1.118" Condition="'$(StyleCop)' == 'true'" />
+    <PackageReference Include="Microsoft.CodeAnalysis.FxCopAnalyzers" PrivateAssets="all" Version="3.0.0" />
+    <PackageReference Include="Microsoft.VisualStudio.Threading.Analyzers" PrivateAssets="all" Version="16.7.54" />
+    <PackageReference Include="MinVer" PrivateAssets="all" Version="2.3.0" />
+    <PackageReference Include="StyleCop.Analyzers" PrivateAssets="all" Version="1.1.118" Condition="'$(StyleCop)' == 'true'" />
   </ItemGroup>
 
 </Project>

--- a/Source/ApiTemplate/Tests/ApiTemplate.IntegrationTest/ApiTemplate.IntegrationTest.csproj
+++ b/Source/ApiTemplate/Tests/ApiTemplate.IntegrationTest/ApiTemplate.IntegrationTest.csproj
@@ -22,7 +22,9 @@
     <PackageReference Include="Moq" Version="4.14.5" />
     <PackageReference Include="Serilog.Sinks.XUnit" Version="2.0.4" />
     <PackageReference Include="xunit" Version="2.4.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3" />
+    <PackageReference Include="xunit.runner.visualstudio" PrivateAssets="all" Version="2.4.3">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
+    </PackageReference>
   </ItemGroup>
 
   <ItemGroup Label="Project References">

--- a/Source/Boxed.Templates.csproj
+++ b/Source/Boxed.Templates.csproj
@@ -25,7 +25,7 @@
   </PropertyGroup>
 
   <ItemGroup Label="Package References">
-    <PackageReference Include="MinVer" PrivateAssets="All" Version="2.3.0" />
+    <PackageReference Include="MinVer" PrivateAssets="all" Version="2.3.0" />
   </ItemGroup>
 
   <ItemGroup Label="Files">

--- a/Source/GraphQLTemplate/Directory.Build.props
+++ b/Source/GraphQLTemplate/Directory.Build.props
@@ -18,10 +18,10 @@
   </PropertyGroup>
 
   <ItemGroup Label="Package References">
-    <PackageReference Include="Microsoft.CodeAnalysis.FxCopAnalyzers" PrivateAssets="All" Version="3.0.0" />
-    <PackageReference Include="Microsoft.VisualStudio.Threading.Analyzers" PrivateAssets="All" Version="16.7.54" />
-    <PackageReference Include="MinVer" PrivateAssets="All" Version="2.3.0" />
-    <PackageReference Include="StyleCop.Analyzers" PrivateAssets="All" Version="1.1.118" Condition="'$(StyleCop)' == 'true'" />
+    <PackageReference Include="Microsoft.CodeAnalysis.FxCopAnalyzers" PrivateAssets="all" Version="3.0.0" />
+    <PackageReference Include="Microsoft.VisualStudio.Threading.Analyzers" PrivateAssets="all" Version="16.7.54" />
+    <PackageReference Include="MinVer" PrivateAssets="all" Version="2.3.0" />
+    <PackageReference Include="StyleCop.Analyzers" PrivateAssets="all" Version="1.1.118" Condition="'$(StyleCop)' == 'true'" />
   </ItemGroup>
 
 </Project>

--- a/Source/GraphQLTemplate/Tests/GraphQLTemplate.IntegrationTest/GraphQLTemplate.IntegrationTest.csproj
+++ b/Source/GraphQLTemplate/Tests/GraphQLTemplate.IntegrationTest/GraphQLTemplate.IntegrationTest.csproj
@@ -22,7 +22,9 @@
     <PackageReference Include="Moq" Version="4.14.5" />
     <PackageReference Include="Serilog.Sinks.XUnit" Version="2.0.4" />
     <PackageReference Include="xunit" Version="2.4.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3" />
+    <PackageReference Include="xunit.runner.visualstudio" PrivateAssets="all" Version="2.4.3">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
+    </PackageReference>
   </ItemGroup>
 
   <ItemGroup Label="ProjectcReferences">

--- a/Source/NuGetTemplate/Directory.Build.props
+++ b/Source/NuGetTemplate/Directory.Build.props
@@ -28,11 +28,11 @@
   </PropertyGroup>
 
   <ItemGroup Label="Package References">
-    <PackageReference Include="Microsoft.CodeAnalysis.FxCopAnalyzers" PrivateAssets="All" Version="3.0.0" />
-    <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" PrivateAssets="All" Version="1.0.0" Condition="'$(DotnetFramework)' == 'true'" />
-    <PackageReference Include="Microsoft.VisualStudio.Threading.Analyzers" PrivateAssets="All" Version="16.7.54" />
-    <PackageReference Include="MinVer" PrivateAssets="All" Version="2.3.0" />
-    <PackageReference Include="StyleCop.Analyzers" PrivateAssets="All" Version="1.1.118" Condition="'$(StyleCop)' == 'true'" />
+    <PackageReference Include="Microsoft.CodeAnalysis.FxCopAnalyzers" PrivateAssets="all" Version="3.0.0" />
+    <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" PrivateAssets="all" Version="1.0.0" Condition="'$(DotnetFramework)' == 'true'" />
+    <PackageReference Include="Microsoft.VisualStudio.Threading.Analyzers" PrivateAssets="all" Version="16.7.54" />
+    <PackageReference Include="MinVer" PrivateAssets="all" Version="2.3.0" />
+    <PackageReference Include="StyleCop.Analyzers" PrivateAssets="all" Version="1.1.118" Condition="'$(StyleCop)' == 'true'" />
   </ItemGroup>
 
 </Project>

--- a/Source/NuGetTemplate/Source/Directory.Build.props
+++ b/Source/NuGetTemplate/Source/Directory.Build.props
@@ -28,11 +28,11 @@
   </PropertyGroup>
 
   <ItemGroup Label="Package References">
-    <PackageReference Include="Microsoft.SourceLink.AzureDevOpsServer.Git" PrivateAssets="All" Version="1.0.0" Condition="'$(AzureDevOpsServer)' == 'true'" />
-    <PackageReference Include="Microsoft.SourceLink.AzureRepos.Git" PrivateAssets="All" Version="1.0.0" Condition="'$(AzureRepos)' == 'true'" />
-    <PackageReference Include="Microsoft.SourceLink.Bitbucket.Git" PrivateAssets="All" Version="1.0.0" Condition="'$(Bitbucket)' == 'true'" />
-    <PackageReference Include="Microsoft.SourceLink.GitHub" PrivateAssets="All" Version="1.0.0" Condition="'$(GitHub)' == 'true'" />
-    <PackageReference Include="Microsoft.SourceLink.GitLab" PrivateAssets="All" Version="1.0.0" Condition="'$(GitLab)' == 'true'" />
+    <PackageReference Include="Microsoft.SourceLink.AzureDevOpsServer.Git" PrivateAssets="all" Version="1.0.0" Condition="'$(AzureDevOpsServer)' == 'true'" />
+    <PackageReference Include="Microsoft.SourceLink.AzureRepos.Git" PrivateAssets="all" Version="1.0.0" Condition="'$(AzureRepos)' == 'true'" />
+    <PackageReference Include="Microsoft.SourceLink.Bitbucket.Git" PrivateAssets="all" Version="1.0.0" Condition="'$(Bitbucket)' == 'true'" />
+    <PackageReference Include="Microsoft.SourceLink.GitHub" PrivateAssets="all" Version="1.0.0" Condition="'$(GitHub)' == 'true'" />
+    <PackageReference Include="Microsoft.SourceLink.GitLab" PrivateAssets="all" Version="1.0.0" Condition="'$(GitLab)' == 'true'" />
   </ItemGroup>
 
   <ItemGroup Label="Files">

--- a/Source/NuGetTemplate/Tests/Directory.Build.props
+++ b/Source/NuGetTemplate/Tests/Directory.Build.props
@@ -3,13 +3,13 @@
   <Import Project="$([MSBuild]::GetPathOfFileAbove('Directory.Build.props', '$(MSBuildThisFileDirectory)../'))" />
 
   <ItemGroup Label="Package References">
-    <PackageReference Include="coverlet.collector" PrivateAssets="All" Version="1.3.0">
+    <PackageReference Include="coverlet.collector" PrivateAssets="all" Version="1.3.0">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.6.1" />
     <PackageReference Include="Moq" Version="4.14.5" />
     <PackageReference Include="xunit" Version="2.4.1" />
-    <PackageReference Include="xunit.runner.visualstudio" PrivateAssets="All" Version="2.4.3">
+    <PackageReference Include="xunit.runner.visualstudio" PrivateAssets="all" Version="2.4.3">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>
   </ItemGroup>

--- a/Source/OrleansTemplate/Directory.Build.props
+++ b/Source/OrleansTemplate/Directory.Build.props
@@ -18,10 +18,10 @@
   </PropertyGroup>
 
   <ItemGroup Label="Package References">
-    <PackageReference Include="Microsoft.CodeAnalysis.FxCopAnalyzers" PrivateAssets="All" Version="3.0.0" />
-    <PackageReference Include="Microsoft.VisualStudio.Threading.Analyzers" PrivateAssets="All" Version="16.7.54" />
-    <PackageReference Include="MinVer" PrivateAssets="All" Version="2.3.0" />
-    <PackageReference Include="StyleCop.Analyzers" PrivateAssets="All" Version="1.1.118" Condition="'$(StyleCop)' == 'true'" />
+    <PackageReference Include="Microsoft.CodeAnalysis.FxCopAnalyzers" PrivateAssets="all" Version="3.0.0" />
+    <PackageReference Include="Microsoft.VisualStudio.Threading.Analyzers" PrivateAssets="all" Version="16.7.54" />
+    <PackageReference Include="MinVer" PrivateAssets="all" Version="2.3.0" />
+    <PackageReference Include="StyleCop.Analyzers" PrivateAssets="all" Version="1.1.118" Condition="'$(StyleCop)' == 'true'" />
   </ItemGroup>
 
 </Project>

--- a/Source/OrleansTemplate/Tests/OrleansTemplate.Server.IntegrationTest/OrleansTemplate.Server.IntegrationTest.csproj
+++ b/Source/OrleansTemplate/Tests/OrleansTemplate.Server.IntegrationTest/OrleansTemplate.Server.IntegrationTest.csproj
@@ -14,7 +14,9 @@
     <PackageReference Include="Serilog.Sinks.Debug" Version="1.0.1" />
     <PackageReference Include="Serilog.Sinks.XUnit" Version="2.0.4" />
     <PackageReference Include="xunit" Version="2.4.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3" />
+    <PackageReference Include="xunit.runner.visualstudio" PrivateAssets="all" Version="2.4.3">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
+    </PackageReference>
   </ItemGroup>
 
   <ItemGroup Label="Project References">


### PR DESCRIPTION
Minor update to add consistency and use `PrivateAssets='all'` for all `xunit.runner.visualstudio` packages.