### PR TITLE
Bump Cake.Tool from 0.38.4 to 0.38.5 & Bump Minver.CLI from 2.3.0 to 2.3.1

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -32,7 +32,6 @@
 *.gif filter=lfs diff=lfs merge=lfs -text
 *.ico filter=lfs diff=lfs merge=lfs -text
 *.jpg filter=lfs diff=lfs merge=lfs -text
-*.pdf filter=lfs diff=lfs merge=lfs -text
 *.png filter=lfs diff=lfs merge=lfs -text
 *.psd filter=lfs diff=lfs merge=lfs -text
 *.webp filter=lfs diff=lfs merge=lfs -text

--- a/Source/ApiTemplate/.gitattributes
+++ b/Source/ApiTemplate/.gitattributes
@@ -32,7 +32,6 @@
 *.gif filter=lfs diff=lfs merge=lfs -text
 *.ico filter=lfs diff=lfs merge=lfs -text
 *.jpg filter=lfs diff=lfs merge=lfs -text
-*.pdf filter=lfs diff=lfs merge=lfs -text
 *.png filter=lfs diff=lfs merge=lfs -text
 *.psd filter=lfs diff=lfs merge=lfs -text
 *.webp filter=lfs diff=lfs merge=lfs -text

--- a/Source/ApiTemplate/dotnet-tools.json
+++ b/Source/ApiTemplate/dotnet-tools.json
@@ -3,13 +3,13 @@
   "isRoot": true,
   "tools": {
     "cake.tool": {
-      "version": "0.38.4",
+      "version": "0.38.5",
       "commands": [
         "dotnet-cake"
       ]
     },
     "minver-cli": {
-      "version": "2.3.0",
+      "version": "2.3.1",
       "commands": [
         "minver"
       ]

--- a/Source/GitattributesTemplate/.gitattributes
+++ b/Source/GitattributesTemplate/.gitattributes
@@ -32,7 +32,6 @@
 *.gif filter=lfs diff=lfs merge=lfs -text
 *.ico filter=lfs diff=lfs merge=lfs -text
 *.jpg filter=lfs diff=lfs merge=lfs -text
-*.pdf filter=lfs diff=lfs merge=lfs -text
 *.png filter=lfs diff=lfs merge=lfs -text
 *.psd filter=lfs diff=lfs merge=lfs -text
 *.webp filter=lfs diff=lfs merge=lfs -text

--- a/Source/GraphQLTemplate/.gitattributes
+++ b/Source/GraphQLTemplate/.gitattributes
@@ -32,7 +32,6 @@
 *.gif filter=lfs diff=lfs merge=lfs -text
 *.ico filter=lfs diff=lfs merge=lfs -text
 *.jpg filter=lfs diff=lfs merge=lfs -text
-*.pdf filter=lfs diff=lfs merge=lfs -text
 *.png filter=lfs diff=lfs merge=lfs -text
 *.psd filter=lfs diff=lfs merge=lfs -text
 *.webp filter=lfs diff=lfs merge=lfs -text

--- a/Source/GraphQLTemplate/dotnet-tools.json
+++ b/Source/GraphQLTemplate/dotnet-tools.json
@@ -3,13 +3,13 @@
   "isRoot": true,
   "tools": {
     "cake.tool": {
-      "version": "0.38.4",
+      "version": "0.38.5",
       "commands": [
         "dotnet-cake"
       ]
     },
     "minver-cli": {
-      "version": "2.3.0",
+      "version": "2.3.1",
       "commands": [
         "minver"
       ]

--- a/Source/NuGetTemplate/.gitattributes
+++ b/Source/NuGetTemplate/.gitattributes
@@ -32,7 +32,6 @@
 *.gif filter=lfs diff=lfs merge=lfs -text
 *.ico filter=lfs diff=lfs merge=lfs -text
 *.jpg filter=lfs diff=lfs merge=lfs -text
-*.pdf filter=lfs diff=lfs merge=lfs -text
 *.png filter=lfs diff=lfs merge=lfs -text
 *.psd filter=lfs diff=lfs merge=lfs -text
 *.webp filter=lfs diff=lfs merge=lfs -text

--- a/Source/NuGetTemplate/dotnet-tools.json
+++ b/Source/NuGetTemplate/dotnet-tools.json
@@ -3,7 +3,7 @@
   "isRoot": true,
   "tools": {
     "cake.tool": {
-      "version": "0.38.4",
+      "version": "0.38.5",
       "commands": [
         "dotnet-cake"
       ]

--- a/Source/OrleansTemplate/.gitattributes
+++ b/Source/OrleansTemplate/.gitattributes
@@ -32,7 +32,6 @@
 *.gif filter=lfs diff=lfs merge=lfs -text
 *.ico filter=lfs diff=lfs merge=lfs -text
 *.jpg filter=lfs diff=lfs merge=lfs -text
-*.pdf filter=lfs diff=lfs merge=lfs -text
 *.png filter=lfs diff=lfs merge=lfs -text
 *.psd filter=lfs diff=lfs merge=lfs -text
 *.webp filter=lfs diff=lfs merge=lfs -text

--- a/Source/OrleansTemplate/dotnet-tools.json
+++ b/Source/OrleansTemplate/dotnet-tools.json
@@ -3,13 +3,13 @@
   "isRoot": true,
   "tools": {
     "cake.tool": {
-      "version": "0.38.4",
+      "version": "0.38.5",
       "commands": [
         "dotnet-cake"
       ]
     },
     "minver-cli": {
-      "version": "2.3.0",
+      "version": "2.3.1",
       "commands": [
         "minver"
       ]

--- a/dotnet-tools.json
+++ b/dotnet-tools.json
@@ -3,7 +3,7 @@
   "isRoot": true,
   "tools": {
     "cake.tool": {
-      "version": "0.38.1",
+      "version": "0.38.5",
       "commands": [
         "dotnet-cake"
       ]


### PR DESCRIPTION
- Bump Cake.Tool from 0.38.4 to 0.38.5
- Bump Minver.CLI from 2.3.0 to 2.3.1
- Remove duplicate line from `.gitattributes`

<!--
Thank you good citizen for your hard work!

Please read the contributing guide before raising a pull request.
https://github.com/Dotnet-Boxed/Templates/blob/master/.github/CONTRIBUTING.md
-->
