### PR TITLE
Fix Windows-style path seperators in tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -352,3 +352,5 @@ MigrationBackup/
 .ionide/
 
 Artefacts/
+
+/.idea

--- a/Tests/Boxed.Templates.FunctionalTest/ApiTemplateTest.cs
+++ b/Tests/Boxed.Templates.FunctionalTest/ApiTemplateTest.cs
@@ -85,7 +85,7 @@ namespace Boxed.Templates.FunctionalTest
                 await project.DotnetTestAsync().ConfigureAwait(false);
                 await project
                     .DotnetRunAsync(
-                        @"Source\ApiDefaults",
+                        Path.Join("Source", "ApiDefaults"),
                         ReadinessCheck.StatusSelfAsync,
                         async (httpClient, httpsClient) =>
                         {
@@ -178,7 +178,7 @@ namespace Boxed.Templates.FunctionalTest
                 await project.DotnetTestAsync().ConfigureAwait(false);
                 await project
                     .DotnetRunAsync(
-                        @"Source\ApiHealthCheckFalse",
+                        Path.Join("Source", "ApiHealthCheckFalse"),
                         ReadinessCheck.FaviconAsync,
                         async (httpClient, httpsClient) =>
                         {
@@ -218,7 +218,7 @@ namespace Boxed.Templates.FunctionalTest
                 await project.DotnetTestAsync().ConfigureAwait(false);
                 await project
                     .DotnetRunAsync(
-                        @"Source\ApiHttpsEverywhereFalse",
+                        Path.Join("Source", "ApiHttpsEverywhereFalse"),
                         ReadinessCheck.StatusSelfOverHttpAsync,
                         async (httpClient, httpsClient) =>
                         {
@@ -259,7 +259,7 @@ namespace Boxed.Templates.FunctionalTest
                 await project.DotnetTestAsync().ConfigureAwait(false);
                 await project
                     .DotnetRunAsync(
-                        @"Source\ApiSwaggerFalse",
+                        Path.Join("Source", "ApiSwaggerFalse"),
                         ReadinessCheck.StatusSelfAsync,
                         async (httpClient, httpsClient) =>
                         {

--- a/Tests/Boxed.Templates.FunctionalTest/GraphQLTemplateTest.cs
+++ b/Tests/Boxed.Templates.FunctionalTest/GraphQLTemplateTest.cs
@@ -84,7 +84,7 @@ namespace Boxed.Templates.FunctionalTest
                 await project.DotnetTestAsync().ConfigureAwait(false);
                 await project
                     .DotnetRunAsync(
-                        @"Source\GraphQLTDefaults",
+                        Path.Join("Source", "GraphQLTDefaults"),
                         ReadinessCheck.StatusSelfAsync,
                         async (httpClient, httpsClient) =>
                         {
@@ -149,7 +149,7 @@ namespace Boxed.Templates.FunctionalTest
                 await project.DotnetTestAsync().ConfigureAwait(false);
                 await project
                     .DotnetRunAsync(
-                        @"Source\GraphQLTHealthCheckFalse",
+                        Path.Join("Source", "GraphQLTHealthCheckFalse"),
                         ReadinessCheck.FaviconAsync,
                         async (httpClient, httpsClient) =>
                         {
@@ -181,7 +181,7 @@ namespace Boxed.Templates.FunctionalTest
                 await project.DotnetTestAsync().ConfigureAwait(false);
                 await project
                     .DotnetRunAsync(
-                        @"Source\GraphQLTDefaults",
+                        Path.Join("Source", "GraphQLTDefaults"),
                         ReadinessCheck.StatusSelfAsync,
                         async (httpClient, httpsClient) =>
                         {
@@ -220,7 +220,7 @@ namespace Boxed.Templates.FunctionalTest
                 await project.DotnetTestAsync().ConfigureAwait(false);
                 await project
                     .DotnetRunAsync(
-                        @"Source\GraphQLTHttpsEverywhereFalse",
+                        Path.Join("Source", "GraphQLTHttpsEverywhereFalse"),
                         ReadinessCheck.StatusSelfOverHttpAsync,
                         async (httpClient, httpsClient) =>
                         {
@@ -261,7 +261,7 @@ namespace Boxed.Templates.FunctionalTest
                 await project.DotnetTestAsync().ConfigureAwait(false);
                 await project
                     .DotnetRunAsync(
-                        @"Source\GraphQLTAuthorizationTrue",
+                        Path.Join("Source", "GraphQLTAuthorizationTrue"),
                         ReadinessCheck.StatusSelfAsync,
                         async (httpClient, httpsClient) =>
                         {
@@ -305,7 +305,7 @@ namespace Boxed.Templates.FunctionalTest
                 await project.DotnetTestAsync().ConfigureAwait(false);
                 await project
                     .DotnetRunAsync(
-                        @"Source\GraphQLTAuthorizationFalse",
+                        Path.Join("Source", "GraphQLTAuthorizationFalse"),
                         ReadinessCheck.StatusSelfAsync,
                         async (httpClient, httpsClient) =>
                         {


### PR DESCRIPTION
Closes #802 

- Change windows-style paths to cross-platform ones. These changes make the tests pass consequently.
- Also gitignores the .idea folder for anyone using  Jetbrains IDE's such as Rider
