### PR TITLE
Improve Template Post Actions

### DIFF
--- a/Source/ApiTemplate/.template.config/dotnetcli.host.json
+++ b/Source/ApiTemplate/.template.config/dotnetcli.host.json
@@ -112,9 +112,6 @@
     "GitHubActions": {
       "longName": "github-actions"
     },
-    "SkipRestore": {
-      "longName": "no-restore"
-    },
     "SkipOpenToDo": {
       "longName": "no-open-todo"
     }

--- a/Source/ApiTemplate/.template.config/template.json
+++ b/Source/ApiTemplate/.template.config/template.json
@@ -1,4 +1,3 @@
-// https://github.com/dotnet/templating/wiki/%22Runnable-Project%22-Templates#configuration
 {
   "$schema": "http://json.schemastore.org/template",
   "author": ".NET Boxed",
@@ -15,7 +14,6 @@
   "sourceName": "ApiTemplate",
   "preferNameDirectory": true,
   "guids": [
-    // User Secret ID
     "113f2d04-69f0-40c3-8797-ba3f356dd812"
   ],
   "primaryOutputs": [
@@ -24,14 +22,12 @@
   "sources": [
     {
       "modifiers": [
-        // EditorConfig
         {
           "condition": "(!EditorConfig)",
           "exclude": [
             ".editorconfig"
           ]
         },
-        // GitHub
         {
           "condition": "(!GitHub)",
           "exclude": [
@@ -42,21 +38,18 @@
             ".github/SECURITY.md"
           ]
         },
-        // ReadMe
         {
           "condition": "(!ReadMe)",
           "exclude": [
             "README.md"
           ]
         },
-        // Swagger
         {
           "condition": "(!Swagger)",
           "exclude": [
             "Source/ApiTemplate/OperationFilters/**/*"
           ]
         },
-        // Versioning
         {
           "condition": "(!Versioning)",
           "exclude": [
@@ -64,7 +57,6 @@
             "Source/ApiTemplate/OperationFilters/**/*"
           ]
         },
-        // ReverseProxyWebServer
         {
           "condition": "(!IIS)",
           "exclude": [
@@ -78,56 +70,48 @@
             "Source/ApiTemplate/nginx.conf"
           ]
         },
-        // CORS
         {
           "condition": "(!CORS)",
           "exclude": [
             "Source/ApiTemplate/Constants/CorsPolicyName.cs"
           ]
         },
-        // ResponseCompression
         {
           "condition": "(!ResponseCompression)",
           "exclude": [
             "Source/ApiTemplate/Options/CompressionOptions.cs"
           ]
         },
-        // RobotsTxt
         {
           "condition": "(!RobotsTxt)",
           "exclude": [
             "Source/ApiTemplate/wwwroot/robots.txt"
           ]
         },
-        // SecurityTxt
         {
           "condition": "(!SecurityTxt)",
           "exclude": [
             "Source/ApiTemplate/wwwroot/.well-known/security.txt"
           ]
         },
-        // HumansTxt
         {
           "condition": "(!HumansTxt)",
           "exclude": [
             "Source/ApiTemplate/wwwroot/humans.txt"
           ]
         },
-        // HealthCheck
         {
           "condition": "(!HealthCheck)",
           "exclude": [
             "Tests/ApiTemplate.IntegrationTest/HealthCheckTest.cs"
           ]
         },
-        // IntegrationTest
         {
           "condition": "(!IntegrationTest)",
           "exclude": [
             "Tests/ApiTemplate.IntegrationTest/**/*"
           ]
         },
-        // Docker
         {
           "condition": "(!Docker)",
           "exclude": [
@@ -135,7 +119,6 @@
             ".dockerignore"
           ]
         },
-        // GitHubActions
         {
           "condition": "(!GitHubActions)",
           "exclude": [
@@ -149,7 +132,6 @@
     }
   ],
   "symbols": {
-    // Title
     "Title": {
       "type": "parameter",
       "datatype": "string",
@@ -163,7 +145,6 @@
       "valueSource": "Title",
       "valueTransform": "xmlEncode"
     },
-    // Description
     "Description": {
       "type": "parameter",
       "datatype": "string",
@@ -177,7 +158,6 @@
       "valueSource": "Description",
       "valueTransform": "xmlEncode"
     },
-    // Author
     "Author": {
       "type": "parameter",
       "datatype": "string",
@@ -191,7 +171,6 @@
       "valueSource": "Author",
       "valueTransform": "xmlEncode"
     },
-    // Contact
     "Contact": {
       "type": "parameter",
       "datatype": "string",
@@ -205,14 +184,12 @@
       "valueSource": "Contact",
       "valueTransform": "xmlEncode"
     },
-    // EditorConfig
     "EditorConfig": {
       "type": "parameter",
       "datatype": "bool",
       "defaultValue": "true",
       "description": "Add a .editorconfig file to set a fixed code style."
     },
-    // SourceControl
     "SourceControl": {
       "type": "parameter",
       "datatype": "choice",
@@ -233,7 +210,6 @@
       "type": "computed",
       "value": "(SourceControl == \"GitHub\")"
     },
-    // GitHubUsername
     "GitHubUsername": {
       "type": "parameter",
       "datatype": "string",
@@ -241,7 +217,6 @@
       "replaces": "GITHUB-USERNAME",
       "description": "Your GitHub username or organisation name that the project lives under."
     },
-    // GitHubProject
     "GitHubProject": {
       "type": "parameter",
       "datatype": "string",
@@ -249,14 +224,12 @@
       "replaces": "GITHUB-PROJECT",
       "description": "The name of your GitHub project."
     },
-    // ReadMe
     "ReadMe": {
       "type": "parameter",
       "datatype": "bool",
       "defaultValue": "true",
       "description": "Add a README.md markdown file describing the project."
     },
-    // TreatWarningsAsErrors
     "TreatWarningsAsErrors": {
       "type": "parameter",
       "datatype": "bool",
@@ -264,35 +237,30 @@
       "description": "Treat warnings as errors."
     },
 
-    // Swagger
     "Swagger": {
       "type": "parameter",
       "datatype": "bool",
       "defaultValue": "true",
       "description": "Swagger is a format for describing the endpoints in your API and letting you try out your site using its user interface."
     },
-    // Versioning
     "Versioning": {
       "type": "parameter",
       "datatype": "bool",
       "defaultValue": "true",
       "description": "Enable API versioning to version API endpoints."
     },
-    // Forwarded Headers
     "ForwardedHeaders": {
       "type": "parameter",
       "datatype": "bool",
       "defaultValue": "true",
       "description": "If you use a load balancer, updates the request host and scheme using the X-Forwarded-Host and X-Forwarded-Proto HTTP headers."
     },
-    // Host Filtering
     "HostFiltering": {
       "type": "parameter",
       "datatype": "bool",
       "defaultValue": "true",
       "description": "A white-list of host names allowed by the Kestrel web server e.g. example.com. You don't need this if you are using a properly configured reverse proxy."
     },
-    // ReverseProxyWebServer
     "ReverseProxyWebServer": {
       "type": "parameter",
       "datatype": "choice",
@@ -325,7 +293,6 @@
       "type": "computed",
       "value": "(ReverseProxyWebServer == \"NGINX\" || ReverseProxyWebServer == \"Both\")"
     },
-    // CloudProvider
     "CloudProvider": {
       "type": "parameter",
       "datatype": "choice",
@@ -346,7 +313,6 @@
       "type": "computed",
       "value": "(CloudProvider == \"Azure\")"
     },
-    // Analytics
     "Analytics": {
       "type": "parameter",
       "datatype": "choice",
@@ -367,49 +333,42 @@
       "type": "computed",
       "value": "(Analytics == \"Application Insights\")"
     },
-    // ApplicationInsightsKey
     "ApplicationInsightsKey": {
       "type": "parameter",
       "datatype": "string",
       "replaces": "APPLICATION-INSIGHTS-INSTRUMENTATION-KEY",
       "description": "Your Application Insights instrumentation key e.g. 11111111-2222-3333-4444-555555555555."
     },
-    // HttpsEverywhere
     "HttpsEverywhere": {
       "type": "parameter",
       "datatype": "bool",
       "defaultValue": "true",
       "description": "Use the HTTPS scheme and TLS security across the entire site, redirects HTTP to HTTPS and adds a Strict Transport Security (HSTS) HTTP header with preloading enabled."
     },
-    // HstsPreload
     "HstsPreload": {
       "type": "parameter",
       "datatype": "bool",
       "defaultValue": "false",
       "description": "Enable Strict Transport Security (HSTS) HTTP header with preloading."
     },
-    // CORS
     "CORS": {
       "type": "parameter",
       "datatype": "bool",
       "defaultValue": "true",
       "description": "Browser security prevents a web page from making AJAX requests to another domain."
     },
-    // ResponseCaching
     "ResponseCaching": {
       "type": "parameter",
       "datatype": "bool",
       "defaultValue": "true",
       "description": "Response caching is allows the use of the [ResponseCache] attribute on your action methods. Cache settings (cache profiles) are stored in the configuration file and referred to by name."
     },
-    // ResponseCompression
     "ResponseCompression": {
       "type": "parameter",
       "datatype": "bool",
       "defaultValue": "true",
       "description": "Enables dynamic GZIP response compression of HTTP responses. Not enabled for HTTPS to avoid the BREACH security vulnerability."
     },
-    // XmlFormatter
     "XmlFormatter": {
       "type": "parameter",
       "datatype": "choice",
@@ -438,35 +397,30 @@
       "type": "computed",
       "value": "(XmlFormatter == \"XmlSerializer\")"
     },
-    // HealthCheck
     "HealthCheck": {
       "type": "parameter",
       "datatype": "bool",
       "defaultValue": "true",
       "description": "A health-check endpoint that returns the status of this API and its dependencies, giving an indication of its health."
     },
-    // RobotsTxt
     "RobotsTxt": {
       "type": "parameter",
       "datatype": "bool",
       "defaultValue": "true",
       "description": "Adds a robots.txt file to tell search engines not to index this site."
     },
-    // SecurityTxt
     "SecurityTxt": {
       "type": "parameter",
       "datatype": "bool",
       "defaultValue": "true",
       "description": "Adds a security.txt file to allow people to contact you if they find a security vulnerability."
     },
-    // HumansTxt
     "HumansTxt": {
       "type": "parameter",
       "datatype": "bool",
       "defaultValue": "true",
       "description": "Adds a humans.txt file where you can tell the world who wrote the application. This file is a good place to thank your developers."
     },
-    // HttpPort
     "HttpPort": {
       "type": "parameter",
       "datatype": "integer",
@@ -485,7 +439,6 @@
       },
       "replaces": "43300"
     },
-    // HttpsPort
     "HttpsPort": {
       "type": "parameter",
       "datatype": "integer",
@@ -526,7 +479,6 @@
       "description": "Adds an optimised Dockerfile to add the ability build a Docker image.",
       "defaultValue": "true"
     },
-    // GitHubActions
     "GitHubActions": {
       "type": "parameter",
       "datatype": "bool",
@@ -534,20 +486,12 @@
       "defaultValue": "true"
     },
 
-    // AuthoringMode
     "AuthoringMode": {
       "type": "generated",
       "generator": "constant",
       "parameters": {
-        "value": false
+        "value": "false"
       }
-    },
-    // https://github.com/dotnet/templating/wiki/Post-Action-Registry
-    "SkipRestore": {
-      "type": "parameter",
-      "datatype": "bool",
-      "description": "Skips the execution of 'dotnet restore' on project creation.",
-      "defaultValue": "false"
     },
     "SkipOpenToDo": {
       "type": "parameter",
@@ -694,22 +638,18 @@
   },
   "postActions": [
     {
-      "actionId": "210D431B-A78B-4D2F-B762-4ED3E3EA9025",
-      "condition": "(!SkipRestore)",
-      "continueOnError": true,
-      "description": "Restore NuGet packages required by this project.",
-      "manualInstructions": [
-        { "text": "Run 'dotnet restore' in the directory the template was created in." }
-      ]
-    },
-    {
-      "actionId": "FEA7469E-E2E7-4431-B86B-27EBC1744883",
+      "actionId": "3A7C4B45-1F5D-4A30-959A-51B88E82B5D2",
       "condition": "(!SkipOpenToDo)",
       "continueOnError": true,
-      "description": "Open the to-do list for the project in a web browser.",
-      "manualInstructions": [
-        { "text": "Open the TODO.html in a web browser to see a to-do list." }
-      ]
+      "description ": "Open the to-do list for the project in a web browser.",
+      "args": {
+        "executable": "powershell.exe",
+        "args": "start TODO.html",
+        "redirectStandardOutput": "false"
+      },
+      "manualInstructions": [{
+         "text": "Open the TODO.html in a web browser to see a to-do list."
+      }]
     }
   ]
 }

--- a/Source/ApiTemplate/TODO.html
+++ b/Source/ApiTemplate/TODO.html
@@ -16,33 +16,29 @@
     <a href="https://github.com/Dotnet-Boxed/Templates">
       <img alt=".NET Boxed"
            class="img-responsive"
-           src="https://raw.githubusercontent.com/Dotnet-Boxed/Templates/master/Images/Banner.png"
+           src="https://media.githubusercontent.com/media/Dotnet-Boxed/Templates/master/Images/Banner.png"
            style="margin-bottom: 20px">
     </a>
 
     <section>
-      <h2>Task Check List</h2>
-      <p>This is a check-list of tasks you must perform to get your site up and running faster. Open this file in the browser of your choice and it will remember what you have checked, just don't clear your cache.</p>
+      <h2>ASP.NET Core API Boxed To-Do List</h2>
+      <p>A short to-do list of tasks to configure your app and set it up for greater performance and security.</p>
 
       <article>
         <h3><span aria-hidden="true" class="fa fa-list"></span> Pre-Requisites</h3>
         <ul class="list-group">
           <li class="list-group-item">
-            <input name="PreRequisites-UpdateVisualStudio" type="checkbox"> <strong>Update Visual Studio / Visual Studio Code</strong> -
-            Update your version of Visual Studio or Visual Studio Code with all patches and updates.
+            <input name="PreRequisites-UpdateVisualStudio" type="checkbox"> <strong>Update Visual Studio/Visual Studio Code</strong> -
+            Update your version of Visual Studio or Visual Studio Code to the latest version.
           </li>
           <li class="list-group-item">
-            <input name="PreRequisites-UpdateNuGet" type="checkbox"> <strong>Update NuGet</strong> -
-            Update the NuGet Visual Studio extension from the Tools -> Extensions and Updates menu.
-          </li>
-          <li class="list-group-item">
-            <input name="PreRequisites-UpdateDNVM" type="checkbox"> <strong>Update Visual Studio ASP.NET Core Tools</strong> -
-            Update the Visual Studio ASP.NET Core tools. Find out more at <a href="https://dot.net">dot.net</a>.
+            <input name="PreRequisites-UpdateDotnetSDK" type="checkbox"> <strong>Update .NET SDK</strong> -
+            Update the .NET SDK. You can download the latest version from <a href="https://dot.net">dot.net</a>.
           </li>
           <!--#if (IIS)-->
           <li class="list-group-item">
-            <input name="PreRequisites-IISNETCoreWindowsServerHosting" type="checkbox"> <strong>IIS .NET Core Windows Server Hosting Bundle</strong> -
-            If you are using IIS and configuring it yourself, install the <a href="https://docs.asp.net/en/latest/publishing/iis.html">.NET Core Windows Server Hosting</a> bundle from <a href="http://go.microsoft.com/fwlink/?LinkId=798480">here</a>.
+            <input name="PreRequisites-IISNETCoreWindowsServerHosting" type="checkbox"> <strong>IIS .NET Hosting Bundle</strong> -
+            If you are hosting your app on IIS, install the <a href="https://docs.microsoft.com/en-us/aspnet/core/host-and-deploy/iis/">IIS .NET Hosting Bundle</a> bundle from <a href="https://docs.microsoft.com/en-us/aspnet/core/host-and-deploy/iis/#install-the-net-core-hosting-bundle">here</a>.
           </li>
           <!--#endif-->
         </ul>
@@ -52,8 +48,12 @@
         <h3><span aria-hidden="true" class="fa fa-lock"></span> API Guidelines</h3>
         <ul class="list-group">
           <li class="list-group-item">
-            <input name="HTTPS-ConfigureHSTSPreload" type="checkbox"> <strong>Zalando REST'ful API Guidelines</strong> -
-            Read the <a href="https://opensource.zalando.com/restful-api-guidelines/">Zalando REST'ful API Guidelines</a>.
+            <input name="APIGuidelines-Microsoft" type="checkbox"> <strong>Microsoft REST API Guidelines</strong> -
+            Read the <a href="https://github.com/microsoft/api-guidelines/">Microsoft REST API Guidelines</a> to learn how to write a REST API.
+          </li>
+          <li class="list-group-item">
+            <input name="APIGuidelines-Zalando" type="checkbox"> <strong>Zalando REST'ful API Guidelines</strong> -
+            Read the <a href="https://opensource.zalando.com/restful-api-guidelines/">Zalando REST'ful API Guidelines</a> to learn how to write a REST API.
           </li>
         </ul>
       </article>
@@ -64,21 +64,12 @@
         <h4>TLS over HTTPS</h4>
         <ul class="list-group">
           <li class="list-group-item">
-            <input name="HTTPS-ConfigureSitewideHTTPS" type="checkbox"> <strong>Configure Site-Wide HTTPS</strong> -
-            Please note that <a href="http://en.wikipedia.org/wiki/SSL">SSL</a> has been superseded by <a href="http://en.wikipedia.org/wiki/Transport_Layer_Security">TLS</a>. SSL is vulnerable to the <a href="http://en.wikipedia.org/wiki/POODLE">POODLE</a> security vulnerability and should not be used. These steps outline how to secure your site so that all requests and responses are made over <a href="http://en.wikipedia.org/wiki/HTTPS">HTTPS</a> using TLS, you should consider using it across your whole site for best security, rather than having a mix of HTTP and HTTPS pages. TLS certificates can be obtained for free at:
-            <ul>
-              <li><a href="https://letsencrypt.org/">LetsEncrypt.org</a></li>
-              <li><a href="https://www.startssl.com/">StartSSL.com</a> (You can follow <a href="http://www.troyhunt.com/2013/09/the-complete-guide-to-loading-free-ssl.html">this</a> guide to setting up TLS using StartSSL.)</li>
-              <li><a href="https://www.digicert.com/friends/mvp.php">Digicert</a> (Digicert is only for Microsoft employees or MVP's)</li>
-            </ul>
+            <input name="HTTPS-SetupTLS" type="checkbox"> <strong>Setup a TLS Certificate</strong> -
+            Obtain a TLS certificate and configure it in your <em>appsettings.json</em> file. See <a href="https://docs.microsoft.com/en-us/aspnet/core/security/enforcing-ssl">this</a> for more information.
           </li>
           <li class="list-group-item">
             <input name="HTTPS-ConfigureHSTSPreload" type="checkbox"> <strong>Configure Strict Transport Security (HSTS) Preloading</strong> -
             If using Strict-Transport-Security, submit your domain to the <a href="https://hstspreload.appspot.com/">HSTS Preload</a> site so that your domain can be preloaded using HTTPS rather than HTTP See <a href="https://developer.mozilla.org/en-US/docs/Web/Security/HTTP_strict_transport_security#Preloading_Strict_Transport_Security">this</a> for more information about preloading.
-          </li>
-          <li class="list-group-item">
-            <input name="HTTPS-ConfigureHPKP" type="checkbox"> <strong>Configure Public Key Pinning (HPKP)</strong> -
-            Open the <em>ApplicationBuilderExtensions.cs</em> file and uncomment the <code>application.UseHpkp(...);</code> line to turn on <a href="https://developer.mozilla.org/en-US/docs/Web/Security/Public_Key_Pinning">Public Key Pinning (HPKP)</a>. Please note that there is some risk to setting up Public Key Pinning (HPKP), if you get it wrong people who have visited your site will get an error in their browser upon visiting your site so be careful.
           </li>
           <li class="list-group-item">
             <input name="HTTPS-TestHttps" type="checkbox"> <strong>Test Your HTTPS Implementation</strong> -
@@ -113,15 +104,15 @@
         <h4>Other Security</h4>
         <ul class="list-group">
           <li class="list-group-item">
+            <input name="OtherSecurity-ConfigureSecurityTxt" type="checkbox"> <strong>Configure security.txt</strong> -
+            <a href="https://securitytxt.org/">Security.txt</a> is a standard which allows you to define a security policy. Edit the <em>security.txt</em> file at the root of the site. This is totally optional, you can delete this file if you want.
+          </li>
+          <li class="list-group-item">
             <input name="OtherSecurity-SecretStore" type="checkbox"> <strong>Use Secret Store</strong> -
-            If you want to use connection strings or other secrets without checking them in to your source control repository, use the secret store. See <a href="http://go.microsoft.com/fwlink/?LinkID=532709">this</a> and <a href="http://docs.asp.net/en/latest/security/app-secrets.html">this</a> for more information.
+            If you want to use connection strings or other secrets without checking them in to your source control repository, use the secret store. See <a href="http://go.microsoft.com/fwlink/?LinkID=532709">this</a> for more information.
           </li>
           <li class="list-group-item">
-            <input name="OtherSecurity-RequestLimits" type="checkbox"> <strong>Adjust Request Limits</strong> -
-            There are settings in the <em>Web.config</em> file under the <code>requestLimits</code> element that limit maximum size of HTTP requests clients can make to your site. You can limit the maximum content size, maximum URL length and maximum query string length. You should lower these as much as possible, while still having a working site.
-          </li>
-          <li class="list-group-item">
-            <input name="OtherSecurity-KeepNuGetUpToDate" type="checkbox"> <strong>Keep NuGet Up To Date</strong> -
+            <input name="OtherSecurity-KeepNuGetUpToDate" type="checkbox"> <strong>Keep NuGet Packages Up To Date</strong> -
             Keep your NuGet packages up to date to patch security vulnerabilities. See the section about updating below.
           </li>
           <!--#if (Azure)-->
@@ -138,11 +129,10 @@
         <h4>Content Delivery Networks (CDN)</h4>
         <ul class="list-group">
           <li class="list-group-item">
-            <input name="ContentDeliveryNetworks-UploadStaticFilesToCDN" type="checkbox"> <strong>Upload Static Files to CDN</strong> -
-            Upload the static files to a <a href="http://en.wikipedia.org/wiki/Content_delivery_network">CDN</a> for vastly better performance.
-            Examples of static content include your images, minified CSS bundle content, minified JavaScript bundle content, etc.
+            <input name="ContentDeliveryNetworks-UploadStaticFilesToCDN" type="checkbox"> <strong>Use a CDN</strong> -
+            Point a <a href="http://en.wikipedia.org/wiki/Content_delivery_network">CDN</a> to your API for vastly better performance.
             <ul>
-              <li><a href="http://www.cloudflare.com/CDN">Cloudflare CDN</a></li>
+              <li><a href="http://www.cloudflare.com">Cloudflare CDN</a></li>
               <li><a href="http://azure.microsoft.com/en-us/documentation/articles/cdn-serve-content-from-cdn-in-your-web-application/">Azure CDN</a></li>
             </ul>
           </li>
@@ -151,24 +141,24 @@
         <ul class="list-group">
           <li class="list-group-item">
             <input name="Caching-ConfigureCaching" type="checkbox"> <strong>Configure Caching</strong> -
-            Some resources are generated programmatically and then cached for a certain time period.
+            Some resources are generated at runtime and then cached for a certain time period.
             If these resources won't change much on your site, change the length of time they are cached. Open the <em>appsettings.json</em> file and take a look at the cache profiles section.
           </li>
           <li class="list-group-item">
             <input name="Caching-AddMoreCaching" type="checkbox"> <strong>Add More Caching</strong> -
-            Use the <code>[ResponseCache]</code> attribute in conjunction with the cache profiles section in the appsettings.json file to cache pages that don't change often and do not contain sensitive information. See
+            Use the <code>[ResponseCache]</code> attribute in conjunction with the cache profiles section in the <em>appsettings.json</em> file to cache pages that don't change often and do not contain sensitive information. See
             <a href="http://www.asp.net/mvc/overview/older-versions-1/controllers-and-routing/improving-performance-with-output-caching-cs">this</a> for more information.
           </li>
         </ul>
         <h4>Benchmarking</h4>
         <ul class="list-group">
           <li class="list-group-item">
-            <input name="OtherPerformance-RunGooglePageSpeed" type="checkbox"> <strong>Run Google Page Speed</strong> -
-            Use <a href="https://developers.google.com/speed/pagespeed/">Google Page Speed</a> to benchmark your sites performance and to get suggestions on how to further improve performance. Note that this template is already very quick to begin with.
+            <input name="OtherPerformance-GoogleLighthouse" type="checkbox"> <strong>Run Google Lighthouse</strong> -
+            Use <a href="https://developers.google.com/web/tools/lighthouse/">Google Lighthouse</a> to benchmark your sites performance and to get suggestions on how to further improve performance.
           </li>
           <li class="list-group-item">
-            <input name="OtherPerformance-RunYahooYSlow" type="checkbox"> <strong>Run Yahoo's YSlow</strong> -
-            Use <a href="http://yslow.org/">Yahoo's YSlow</a> to benchmark your sites performance and to get suggestions on how to further improve performance.
+            <input name="OtherPerformance-Webhint" type="checkbox"> <strong>Run Webhint</strong> -
+            Use <a href="https://webhint.io/">Webhint</a> to benchmark your sites performance and to get suggestions on how to further improve performance.
           </li>
         </ul>
         <h4>Other Performance</h4>
@@ -180,76 +170,24 @@
         </ul>
       </article>
 
-      <article>
-        <h3><span aria-hidden="true" class="fa fa-puzzle-piece"></span> Compatibility</h3>
-        <ul class="list-group">
-          <!--#if (IIS)-->
-          <li class="list-group-item">
-            <input name="Compatibility-OldIIS" type="checkbox"> <strong>IIS 7.5/8</strong> -
-            Some <em>web.config</em> settings do not exist in older versions of IIS (7.5 and 8). If you are using an older version, edit the <em>web.config</em> file and remove the <code>dynamicIpSecurity</code> settings.
-          </li>
-          <!--#endif-->
-        </ul>
-      </article>
-
-      <article>
-        <h3><span aria-hidden="true" class="fa fa-user"></span> Authentication &amp; Authorization</h3>
-        <ul class="list-group">
-          <li class="list-group-item">
-            <input name="Authentication-Provider" type="checkbox"> <strong>Choose Authentication Provider</strong> -
-            If you want no authentication, then you don't need to do anything. <strong>Do not</strong> build your own authentication provider unless you are a security expert, it is much harder than it looks and even professionals get it wrong. Choose from one of the options below:
-            <ol>
-              <li>IdentityServer4 - This is another site that handles all authentication with OAuth and Open ID Connect.</li>
-              <li>ASP.NET Identity - This is basically forms authentication with OAuth and Open ID Connect. This is what you get when you select 'Individual Account' from Microsoft's '<a href="http://i2.asp.net/media/47397/ConfigureAuthDialog.png?cdn_id=2015-05-22-001">Change Authentication</a>' dialogue, when you create a new Web Project. Follow <a href="http://www.asp.net/identity/overview/getting-started">this</a> tutorial. Don't forget to add the <code>NoLowercaseQueryStringAttribute</code> to the <code>AccountController</code> to enable the <code>RedirectToCanonicalUrlAttribute</code> to work (See comments on these classes for more information about what they do).</li>
-              <li>Windows Authentication - Follow <a href="http://www.asp.net/aspnet/overview/owin-and-katana/enabling-windows-authentication-in-katana">this</a> tutorial.</li>
-            </ol>
-          </li>
-        </ul>
-      </article>
-
+      <!--#if (ApplicationInsights)-->
       <article>
         <h3><span aria-hidden="true" class="fa fa-exclamation-triangle"></span> Resilience and Error Handling</h3>
         <ul class="list-group">
-
-          <li class="list-group-item">
-            <input name="ResilienceAndErrorHandling-DosProtection" type="checkbox"> <strong>Denial of Service (DoS) Protection</strong> -
-            There are a number of ways to protect your site from <a href="http://en.wikipedia.org/wiki/Denial-of-service_attack">Denial of Service (DoS)</a> attacks:
-            <ul>
-              <li>
-                <a href="https://www.cloudflare.com/">Cloudflare</a> - You can use the Cloudflare service as a proxy to your site. Cloudflare has sophisticated techniques to block attackers from accessing your site and is used by a large proportion of websites on the internet.
-              </li>
-              <!--#if (IIS)-->
-              <li>
-                <a href="http://www.iis.net/configreference/system.webserver/security/dynamicipsecurity">Dynamic IP Security</a> is a feature of IIS that can be configured using the <code>dynamicIpSecurity</code> section of the <em>web.config</em> file. Dynamic IP Security is set to logging only mode in this site, so IIS will log malicious requests from clients without actually rejecting them. If you decide to use this feature, run your site in this mode for some time and slowly raise the limits until you get no more 403.501 or 403.502 errors. Normal legitimate requests that can look like a DoS attack are:
-                <ol>
-                  <li>Google and Bing often make large numbers of requests that can look like a DoS attack and you do not want to block them by accident.</li>
-                  <li>Some organizations put themselves behind a proxy and their requests can look like they are from a single IP address.</li>
-                  <li>Pages on your site that cause a large number of requests to be made your site may trigger the Dynamic IP Security limits to be triggered and the page loading will be treated like a Denial of Service (DoS) attack.</li>
-                </ol>
-                You can test this feature by recording a request to your site using <a href="http://www.telerik.com/fiddler">Fiddler</a> and then replaying it many times.
-              </li>
-              <!--#endif-->
-            </ul>
-          </li>
-          <!--#if (ApplicationInsights)-->
           <li class="list-group-item">
             <input name="ResilienceAndErrorHandling-ApplicationInsights" type="checkbox"> <strong>Application Insights</strong> -
             Application Insights helps monitor your site and know about it when it goes down. Login to <a href="http://azure.microsoft.com">Azure</a>, create a new Application Insights instance, retrieve the Instrumentation Key and add it to your <em>appsettings.json</em> file. For more information see the <a href="http://docs.asp.net/en/latest/fundamentals/application-insights.html">Getting Started</a> guide.
           </li>
-          <!--#endif-->
-          <li class="list-group-item">
-            <input name="ResilienceAndErrorHandling-Logging" type="checkbox"> <strong>Add Logging</strong> -
-            This template comes with basic logging enabled in development mode. Consider using <a href="http://serilog.net/">Serilog</a> or another logging framework in production. Logging can be configured in <em>Startup.cs</em>.
-          </li>
         </ul>
       </article>
+      <!--#endif-->
 
       <article>
         <h3><span aria-hidden="true" class="fa fa-users"></span> Thank Developers</h3>
         <ul class="list-group">
           <li class="list-group-item">
-            <input name="ThankDevelopers-ConfigureHumansTxt" type="checkbox"> <strong>Configure Humans.txt</strong> -
-            Edit the <em>humans.txt</em> file at the root of the site. This is totally optional, you can delete this file if you want.
+            <input name="ThankDevelopers-ConfigureHumansTxt" type="checkbox"> <strong>Configure humans.txt</strong> -
+            <a href="http://humanstxt.org/">Humans.txt</a> is a standard way of describing and thanking the people that built your app. Edit the <em>humans.txt</em> file at the root of the app. This is totally optional, you can delete this file if you want.
             Be careful what you put into this file, you could give away clues about potential attack vectors on your site.
             Even giving contact details can be an attack vector (Most hackers manipulate people to get access).
           </li>
@@ -265,12 +203,7 @@
         <ul class="list-group">
           <li class="list-group-item">
             <input name="KeepingYourSiteUpToDate-KeepNuGetPackagesUpToDate" type="checkbox"> <strong>Keep NuGet Packages Up To Date</strong> -
-            Most updates can be easily carried out by simply updating <a href="https://www.nuget.org/">NuGet</a> packages. See <a href="https://docs.nuget.org/consume/package-manager-dialog">this</a> link for more information. However, there are a few things to watch out for before updating a package:
-            <ol>
-              <li>It's worth reading the NuGet package release notes to see what has changed and base the urgency of upgrading on this information. Blindly updating, can sometimes cause things to break. Sometimes packages are incompatible with other packages or there are special upgrade steps that need to be carried out.</li>
-              <li>When updating JavaScript or CSS framework Bower Packages, be careful that the particular version you are updating to is also available on the <a href="http://en.wikipedia.org/wiki/Content_delivery_network">CDN</a>. Some CDN's update more often than others. This project template uses the popular Google and Microsoft CDN's as it is likely that their scripts are already preloaded in a browsers cache. However, their CDN service also does not update too often.</li>
-              <li>You need to ensure that you update your JavaScript and CSS framework Bower packages when there are new versions to obtain security patches but also because <a href="http://en.wikipedia.org/wiki/Content_delivery_network">CDN</a>'s sometimes retire very old scripts. This template provides fallback scripts, so if a CDN does retire a script or goes down, it will use the scripts in this template instead. This will result in a slight performance degradation.</li>
-            </ol>
+            Most updates can be easily carried out by simply updating <a href="https://www.nuget.org/">NuGet</a> packages. See <a href="https://docs.nuget.org/consume/package-manager-dialog">this</a> link for more information.
           </li>
           <li class="list-group-item">
             <input name="KeepingYourSiteUpToDate-KeepTemplateUpToDate" type="checkbox"> <strong>Keep Template Up To Date</strong> -

--- a/Source/GraphQLTemplate/.template.config/dotnetcli.host.json
+++ b/Source/GraphQLTemplate/.template.config/dotnetcli.host.json
@@ -109,9 +109,6 @@
     "GitHubActions": {
       "longName": "github-actions"
     },
-    "SkipRestore": {
-      "longName": "no-restore"
-    },
     "SkipOpenToDo": {
       "longName": "no-open-todo"
     }

--- a/Source/GraphQLTemplate/.template.config/template.json
+++ b/Source/GraphQLTemplate/.template.config/template.json
@@ -1,4 +1,3 @@
-// https://github.com/dotnet/templating/wiki/%22Runnable-Project%22-Templates#configuration
 {
   "$schema": "http://json.schemastore.org/template",
   "author": ".NET Boxed",
@@ -15,7 +14,6 @@
   "sourceName": "GraphQLTemplate",
   "preferNameDirectory": true,
   "guids": [
-    // User Secret ID
     "113f2d04-69f0-40c3-8797-ba3f356dd812"
   ],
   "primaryOutputs": [
@@ -24,14 +22,12 @@
   "sources": [
     {
       "modifiers": [
-        // EditorConfig
         {
           "condition": "(!EditorConfig)",
           "exclude": [
             ".editorconfig"
           ]
         },
-        // GitHub
         {
           "condition": "(!GitHub)",
           "exclude": [
@@ -42,28 +38,24 @@
             ".github/SECURITY.md"
           ]
         },
-        // ReadMe
         {
           "condition": "(!ReadMe)",
           "exclude": [
             "README.md"
           ]
         },
-        // Mutations
         {
           "condition": "(!Mutations)",
           "exclude": [
             "Source/GraphQLTemplate/Schemas/RootMutation.cs"
           ]
         },
-        // Subscriptions
         {
           "condition": "(!Subscriptions)",
           "exclude": [
             "Source/GraphQLTemplate/Schemas/RootSubscription.cs"
           ]
         },
-        // ReverseProxyWebServer
         {
           "condition": "(!IIS)",
           "exclude": [
@@ -77,63 +69,54 @@
             "Source/GraphQLTemplate/nginx.conf"
           ]
         },
-        // Authorization
         {
           "condition": "(!Authorization)",
           "exclude": [
             "Source/GraphQLTemplate/Constants/AuthorizationPolicyName.cs"
           ]
         },
-        // CORS
         {
           "condition": "(!CORS)",
           "exclude": [
             "Source/GraphQLTemplate/Constants/CorsPolicyName.cs"
           ]
         },
-        // ResponseCompression
         {
           "condition": "(!ResponseCompression)",
           "exclude": [
             "Source/GraphQLTemplate/Options/CompressionOptions.cs"
           ]
         },
-        // RobotsTxt
         {
           "condition": "(!RobotsTxt)",
           "exclude": [
             "Source/GraphQLTemplate/wwwroot/robots.txt"
           ]
         },
-        // SecurityTxt
         {
           "condition": "(!SecurityTxt)",
           "exclude": [
             "Source/GraphQLTemplate/wwwroot/.well-known/security.txt"
           ]
         },
-        // HumansTxt
         {
           "condition": "(!HumansTxt)",
           "exclude": [
             "Source/GraphQLTemplate/wwwroot/humans.txt"
           ]
         },
-        // HealthCheck
         {
           "condition": "(!HealthCheck)",
           "exclude": [
             "Tests/GraphQLTemplate.IntegrationTest/HealthCheckTest.cs"
           ]
         },
-        // IntegrationTest
         {
           "condition": "(!IntegrationTest)",
           "exclude": [
             "Tests/ApiTemplate.IntegrationTest/**/*"
           ]
         },
-        // Docker
         {
           "condition": "(!Docker)",
           "exclude": [
@@ -141,7 +124,6 @@
             ".dockerignore"
           ]
         },
-        // GitHubActions
         {
           "condition": "(!GitHubActions)",
           "exclude": [
@@ -155,7 +137,6 @@
     }
   ],
   "symbols": {
-    // Title
     "Title": {
       "type": "parameter",
       "datatype": "string",
@@ -169,7 +150,6 @@
       "valueSource": "Title",
       "valueTransform": "xmlEncode"
     },
-    // Description
     "Description": {
       "type": "parameter",
       "datatype": "string",
@@ -183,7 +163,6 @@
       "valueSource": "Description",
       "valueTransform": "xmlEncode"
     },
-    // Author
     "Author": {
       "type": "parameter",
       "datatype": "string",
@@ -197,7 +176,6 @@
       "valueSource": "Author",
       "valueTransform": "xmlEncode"
     },
-    // Contact
     "Contact": {
       "type": "parameter",
       "datatype": "string",
@@ -211,14 +189,12 @@
       "valueSource": "Contact",
       "valueTransform": "xmlEncode"
     },
-    // EditorConfig
     "EditorConfig": {
       "type": "parameter",
       "datatype": "bool",
       "defaultValue": "true",
       "description": "Add a .editorconfig file to set a fixed code style."
     },
-    // SourceControl
     "SourceControl": {
       "type": "parameter",
       "datatype": "choice",
@@ -239,7 +215,6 @@
       "type": "computed",
       "value": "(SourceControl == \"GitHub\")"
     },
-    // GitHubUsername
     "GitHubUsername": {
       "type": "parameter",
       "datatype": "string",
@@ -247,7 +222,6 @@
       "replaces": "GITHUB-USERNAME",
       "description": "Your GitHub username or organisation name that the project lives under."
     },
-    // GitHubProject
     "GitHubProject": {
       "type": "parameter",
       "datatype": "string",
@@ -255,14 +229,12 @@
       "replaces": "GITHUB-PROJECT",
       "description": "The name of your GitHub project."
     },
-    // ReadMe
     "ReadMe": {
       "type": "parameter",
       "datatype": "bool",
       "defaultValue": "true",
       "description": "Add a README.md markdown file describing the project."
     },
-    // TreatWarningsAsErrors
     "TreatWarningsAsErrors": {
       "type": "parameter",
       "datatype": "bool",
@@ -270,35 +242,30 @@
       "description": "Treat warnings as errors."
     },
 
-    // Mutations
     "Mutations": {
       "type": "parameter",
       "datatype": "bool",
       "defaultValue": "true",
       "description": "Add GraphQL mutations to change objects."
     },
-    // Subscriptions
     "Subscriptions": {
       "type": "parameter",
       "datatype": "bool",
       "defaultValue": "true",
       "description": "Add GraphQL subscriptions to be notified when objects change."
     },
-    // Forwarded Headers
     "ForwardedHeaders": {
       "type": "parameter",
       "datatype": "bool",
       "defaultValue": "true",
       "description": "If you use a load balancer, updates the request host and scheme using the X-Forwarded-Host and X-Forwarded-Proto HTTP headers."
     },
-    // Host Filtering
     "HostFiltering": {
       "type": "parameter",
       "datatype": "bool",
       "defaultValue": "true",
       "description": "A white-list of host names allowed by the Kestrel web server e.g. example.com. You don't need this if you are using a properly configured reverse proxy."
     },
-    // ReverseProxyWebServer
     "ReverseProxyWebServer": {
       "type": "parameter",
       "datatype": "choice",
@@ -331,7 +298,6 @@
       "type": "computed",
       "value": "(ReverseProxyWebServer == \"NGINX\" || ReverseProxyWebServer == \"Both\")"
     },
-    // CloudProvider
     "CloudProvider": {
       "type": "parameter",
       "datatype": "choice",
@@ -352,7 +318,6 @@
       "type": "computed",
       "value": "(CloudProvider == \"Azure\")"
     },
-    // Analytics
     "Analytics": {
       "type": "parameter",
       "datatype": "choice",
@@ -373,77 +338,66 @@
       "type": "computed",
       "value": "(Analytics == \"Application Insights\")"
     },
-    // ApplicationInsightsKey
     "ApplicationInsightsKey": {
       "type": "parameter",
       "datatype": "string",
       "replaces": "APPLICATION-INSIGHTS-INSTRUMENTATION-KEY",
       "description": "Your Application Insights instrumentation key e.g. 11111111-2222-3333-4444-555555555555."
     },
-    // HttpsEverywhere
     "HttpsEverywhere": {
       "type": "parameter",
       "datatype": "bool",
       "defaultValue": "true",
       "description": "Use the HTTPS scheme and TLS security across the entire site, redirects HTTP to HTTPS and adds a Strict Transport Security (HSTS) HTTP header with preloading enabled."
     },
-    // HstsPreload
     "HstsPreload": {
       "type": "parameter",
       "datatype": "bool",
       "defaultValue": "false",
       "description": "Enable Strict Transport Security (HSTS) HTTP header with preloading."
     },
-    // Authorization
     "Authorization": {
       "type": "parameter",
       "datatype": "bool",
       "defaultValue": "true",
       "description": "Enable the use of authorization policies to secure GraphQL types and fields by requiring certain claims. You need to setup authentication yourself."
     },
-    // CORS
     "CORS": {
       "type": "parameter",
       "datatype": "bool",
       "defaultValue": "true",
       "description": "Browser security prevents a web page from making AJAX requests to another domain."
     },
-    // ResponseCompression
     "ResponseCompression": {
       "type": "parameter",
       "datatype": "bool",
       "defaultValue": "true",
       "description": "Enables dynamic GZIP response compression of HTTP responses. Not enabled for HTTPS to avoid the BREACH security vulnerability."
     },
-    // HealthCheck
     "HealthCheck": {
       "type": "parameter",
       "datatype": "bool",
       "defaultValue": "true",
       "description": "A health-check endpoint that returns the status of this API and its dependencies, giving an indication of its health."
     },
-    // RobotsTxt
     "RobotsTxt": {
       "type": "parameter",
       "datatype": "bool",
       "defaultValue": "true",
       "description": "Adds a robots.txt file to tell search engines not to index this site."
     },
-    // SecurityTxt
     "SecurityTxt": {
       "type": "parameter",
       "datatype": "bool",
       "defaultValue": "true",
       "description": "Adds a security.txt file to allow people to contact you if they find a security vulnerability."
     },
-    // HumansTxt
     "HumansTxt": {
       "type": "parameter",
       "datatype": "bool",
       "defaultValue": "true",
       "description": "Adds a humans.txt file where you can tell the world who wrote the application. This file is a good place to thank your developers."
     },
-    // HttpPort
     "HttpPort": {
       "type": "parameter",
       "datatype": "integer",
@@ -462,7 +416,6 @@
       },
       "replaces": "43300"
     },
-    // HttpsPort
     "HttpsPort": {
       "type": "parameter",
       "datatype": "integer",
@@ -503,7 +456,6 @@
       "description": "Adds an optimised Dockerfile to add the ability build a Docker image.",
       "defaultValue": "true"
     },
-    // GitHubActions
     "GitHubActions": {
       "type": "parameter",
       "datatype": "bool",
@@ -511,20 +463,12 @@
       "defaultValue": "true"
     },
 
-    // AuthoringMode
     "AuthoringMode": {
       "type": "generated",
       "generator": "constant",
       "parameters": {
-        "value": false
+        "value": "false"
       }
-    },
-    // https://github.com/dotnet/templating/wiki/Post-Action-Registry
-    "SkipRestore": {
-      "type": "parameter",
-      "datatype": "bool",
-      "description": "Skips the execution of 'dotnet restore' on project creation.",
-      "defaultValue": "false"
     },
     "SkipOpenToDo": {
       "type": "parameter",
@@ -671,22 +615,18 @@
   },
   "postActions": [
     {
-      "actionId": "210D431B-A78B-4D2F-B762-4ED3E3EA9025",
-      "condition": "(!SkipRestore)",
-      "continueOnError": true,
-      "description": "Restore NuGet packages required by this project.",
-      "manualInstructions": [
-        { "text": "Run 'dotnet restore' in the directory the template was created in." }
-      ]
-    },
-    {
-      "actionId": "FEA7469E-E2E7-4431-B86B-27EBC1744883",
+      "actionId": "3A7C4B45-1F5D-4A30-959A-51B88E82B5D2",
       "condition": "(!SkipOpenToDo)",
       "continueOnError": true,
-      "description": "Open the to-do list for the project in a web browser.",
-      "manualInstructions": [
-        { "text": "Open the TODO.html in a web browser to see a to-do list." }
-      ]
+      "description ": "Open the to-do list for the project in a web browser.",
+      "args": {
+        "executable": "powershell.exe",
+        "args": "start TODO.html",
+        "redirectStandardOutput": "false"
+      },
+      "manualInstructions": [{
+         "text": "Open the TODO.html in a web browser to see a to-do list."
+      }]
     }
   ]
 }

--- a/Source/GraphQLTemplate/TODO.html
+++ b/Source/GraphQLTemplate/TODO.html
@@ -13,36 +13,32 @@
 <body>
   <div id="main" class="container body-content" role="main">
 
-    <a href="Dotnet-Boxed/Templates">
+    <a href="https://github.com/Dotnet-Boxed/Templates">
       <img alt=".NET Boxed"
            class="img-responsive"
-           src="https://raw.githubusercontent.com/Dotnet-Boxed/Templates/master/Images/Banner.png"
+           src="https://media.githubusercontent.com/media/Dotnet-Boxed/Templates/master/Images/Banner.png"
            style="margin-bottom: 20px">
     </a>
 
     <section>
-      <h2>Task Check List</h2>
-      <p>This is a check-list of tasks you must perform to get your site up and running faster. Open this file in the browser of your choice and it will remember what you have checked, just don't clear your cache.</p>
+      <h2>ASP.NET Core GraphQL Boxed To-Do List</h2>
+      <p>A short to-do list of tasks to configure your app and set it up for greater performance and security.</p>
 
       <article>
         <h3><span aria-hidden="true" class="fa fa-list"></span> Pre-Requisites</h3>
         <ul class="list-group">
           <li class="list-group-item">
-            <input name="PreRequisites-UpdateVisualStudio" type="checkbox"> <strong>Update Visual Studio / Visual Studio Code</strong> -
-            Update your version of Visual Studio or Visual Studio Code with all patches and updates.
+            <input name="PreRequisites-UpdateVisualStudio" type="checkbox"> <strong>Update Visual Studio/Visual Studio Code</strong> -
+            Update your version of Visual Studio or Visual Studio Code to the latest version.
           </li>
           <li class="list-group-item">
-            <input name="PreRequisites-UpdateNuGet" type="checkbox"> <strong>Update NuGet</strong> -
-            Update the NuGet Visual Studio extension from the Tools -> Extensions and Updates menu.
-          </li>
-          <li class="list-group-item">
-            <input name="PreRequisites-UpdateDNVM" type="checkbox"> <strong>Update Visual Studio ASP.NET Core Tools</strong> -
-            Update the Visual Studio ASP.NET Core tools. Find out more at <a href="https://dot.net">dot.net</a>.
+            <input name="PreRequisites-UpdateDotnetSDK" type="checkbox"> <strong>Update .NET SDK</strong> -
+            Update the .NET SDK. You can download the latest version from <a href="https://dot.net">dot.net</a>.
           </li>
           <!--#if (IIS)-->
           <li class="list-group-item">
-            <input name="PreRequisites-IISNETCoreWindowsServerHosting" type="checkbox"> <strong>IIS .NET Core Windows Server Hosting Bundle</strong> -
-            If you are using IIS and configuring it yourself, install the <a href="https://docs.asp.net/en/latest/publishing/iis.html">.NET Core Windows Server Hosting</a> bundle from <a href="http://go.microsoft.com/fwlink/?LinkId=798480">here</a>.
+            <input name="PreRequisites-IISNETCoreWindowsServerHosting" type="checkbox"> <strong>IIS .NET Hosting Bundle</strong> -
+            If you are hosting your app on IIS, install the <a href="https://docs.microsoft.com/en-us/aspnet/core/host-and-deploy/iis/">IIS .NET Hosting Bundle</a> bundle from <a href="https://docs.microsoft.com/en-us/aspnet/core/host-and-deploy/iis/#install-the-net-core-hosting-bundle">here</a>.
           </li>
           <!--#endif-->
         </ul>
@@ -54,21 +50,12 @@
         <h4>TLS over HTTPS</h4>
         <ul class="list-group">
           <li class="list-group-item">
-            <input name="HTTPS-ConfigureSitewideHTTPS" type="checkbox"> <strong>Configure Site-Wide HTTPS</strong> -
-            Please note that <a href="http://en.wikipedia.org/wiki/SSL">SSL</a> has been superseded by <a href="http://en.wikipedia.org/wiki/Transport_Layer_Security">TLS</a>. SSL is vulnerable to the <a href="http://en.wikipedia.org/wiki/POODLE">POODLE</a> security vulnerability and should not be used. These steps outline how to secure your site so that all requests and responses are made over <a href="http://en.wikipedia.org/wiki/HTTPS">HTTPS</a> using TLS, you should consider using it across your whole site for best security, rather than having a mix of HTTP and HTTPS pages. TLS certificates can be obtained for free at:
-            <ul>
-              <li><a href="https://letsencrypt.org/">LetsEncrypt.org</a></li>
-              <li><a href="https://www.startssl.com/">StartSSL.com</a> (You can follow <a href="http://www.troyhunt.com/2013/09/the-complete-guide-to-loading-free-ssl.html">this</a> guide to setting up TLS using StartSSL.)</li>
-              <li><a href="https://www.digicert.com/friends/mvp.php">Digicert</a> (Digicert is only for Microsoft employees or MVP's)</li>
-            </ul>
+            <input name="HTTPS-SetupTLS" type="checkbox"> <strong>Setup a TLS Certificate</strong> -
+            Obtain a TLS certificate and configure it in your <em>appsettings.json</em> file. See <a href="https://docs.microsoft.com/en-us/aspnet/core/security/enforcing-ssl">this</a> for more information.
           </li>
           <li class="list-group-item">
             <input name="HTTPS-ConfigureHSTSPreload" type="checkbox"> <strong>Configure Strict Transport Security (HSTS) Preloading</strong> -
             If using Strict-Transport-Security, submit your domain to the <a href="https://hstspreload.appspot.com/">HSTS Preload</a> site so that your domain can be preloaded using HTTPS rather than HTTP See <a href="https://developer.mozilla.org/en-US/docs/Web/Security/HTTP_strict_transport_security#Preloading_Strict_Transport_Security">this</a> for more information about preloading.
-          </li>
-          <li class="list-group-item">
-            <input name="HTTPS-ConfigureHPKP" type="checkbox"> <strong>Configure Public Key Pinning (HPKP)</strong> -
-            Open the <em>ApplicationBuilderExtensions.cs</em> file and uncomment the <code>application.UseHpkp(...);</code> line to turn on <a href="https://developer.mozilla.org/en-US/docs/Web/Security/Public_Key_Pinning">Public Key Pinning (HPKP)</a>. Please note that there is some risk to setting up Public Key Pinning (HPKP), if you get it wrong people who have visited your site will get an error in their browser upon visiting your site so be careful.
           </li>
           <li class="list-group-item">
             <input name="HTTPS-TestHttps" type="checkbox"> <strong>Test Your HTTPS Implementation</strong> -
@@ -103,15 +90,15 @@
         <h4>Other Security</h4>
         <ul class="list-group">
           <li class="list-group-item">
+            <input name="OtherSecurity-ConfigureSecurityTxt" type="checkbox"> <strong>Configure security.txt</strong> -
+            <a href="https://securitytxt.org/">Security.txt</a> is a standard which allows you to define a security policy. Edit the <em>security.txt</em> file at the root of the site. This is totally optional, you can delete this file if you want.
+          </li>
+          <li class="list-group-item">
             <input name="OtherSecurity-SecretStore" type="checkbox"> <strong>Use Secret Store</strong> -
-            If you want to use connection strings or other secrets without checking them in to your source control repository, use the secret store. See <a href="http://go.microsoft.com/fwlink/?LinkID=532709">this</a> and <a href="http://docs.asp.net/en/latest/security/app-secrets.html">this</a> for more information.
+            If you want to use connection strings or other secrets without checking them in to your source control repository, use the secret store. See <a href="http://go.microsoft.com/fwlink/?LinkID=532709">this</a> for more information.
           </li>
           <li class="list-group-item">
-            <input name="OtherSecurity-RequestLimits" type="checkbox"> <strong>Adjust Request Limits</strong> -
-            There are settings in the <em>Web.config</em> file under the <code>requestLimits</code> element that limit maximum size of HTTP requests clients can make to your site. You can limit the maximum content size, maximum URL length and maximum query string length. You should lower these as much as possible, while still having a working site.
-          </li>
-          <li class="list-group-item">
-            <input name="OtherSecurity-KeepNuGetUpToDate" type="checkbox"> <strong>Keep NuGet Up To Date</strong> -
+            <input name="OtherSecurity-KeepNuGetUpToDate" type="checkbox"> <strong>Keep NuGet Packages Up To Date</strong> -
             Keep your NuGet packages up to date to patch security vulnerabilities. See the section about updating below.
           </li>
           <!--#if (Azure)-->
@@ -128,11 +115,10 @@
         <h4>Content Delivery Networks (CDN)</h4>
         <ul class="list-group">
           <li class="list-group-item">
-            <input name="ContentDeliveryNetworks-UploadStaticFilesToCDN" type="checkbox"> <strong>Upload Static Files to CDN</strong> -
-            Upload the static files to a <a href="http://en.wikipedia.org/wiki/Content_delivery_network">CDN</a> for vastly better performance.
-            Examples of static content include your images, minified CSS bundle content, minified JavaScript bundle content, etc.
+            <input name="ContentDeliveryNetworks-UploadStaticFilesToCDN" type="checkbox"> <strong>Use a CDN</strong> -
+            Point a <a href="http://en.wikipedia.org/wiki/Content_delivery_network">CDN</a> to your API for vastly better performance.
             <ul>
-              <li><a href="http://www.cloudflare.com/CDN">Cloudflare CDN</a></li>
+              <li><a href="http://www.cloudflare.com">Cloudflare CDN</a></li>
               <li><a href="http://azure.microsoft.com/en-us/documentation/articles/cdn-serve-content-from-cdn-in-your-web-application/">Azure CDN</a></li>
             </ul>
           </li>
@@ -141,19 +127,19 @@
         <ul class="list-group">
           <li class="list-group-item">
             <input name="Caching-ConfigureCaching" type="checkbox"> <strong>Configure Caching</strong> -
-            Some resources are generated programmatically and then cached for a certain time period.
+            Some resources are generated at runtime and then cached for a certain time period.
             If these resources won't change much on your site, change the length of time they are cached. Open the <em>appsettings.json</em> file and take a look at the cache profiles section.
           </li>
         </ul>
         <h4>Benchmarking</h4>
         <ul class="list-group">
           <li class="list-group-item">
-            <input name="OtherPerformance-RunGooglePageSpeed" type="checkbox"> <strong>Run Google Page Speed</strong> -
-            Use <a href="https://developers.google.com/speed/pagespeed/">Google Page Speed</a> to benchmark your sites performance and to get suggestions on how to further improve performance. Note that this template is already very quick to begin with.
+            <input name="OtherPerformance-GoogleLighthouse" type="checkbox"> <strong>Run Google Lighthouse</strong> -
+            Use <a href="https://developers.google.com/web/tools/lighthouse/">Google Lighthouse</a> to benchmark your sites performance and to get suggestions on how to further improve performance.
           </li>
           <li class="list-group-item">
-            <input name="OtherPerformance-RunYahooYSlow" type="checkbox"> <strong>Run Yahoo's YSlow</strong> -
-            Use <a href="http://yslow.org/">Yahoo's YSlow</a> to benchmark your sites performance and to get suggestions on how to further improve performance.
+            <input name="OtherPerformance-Webhint" type="checkbox"> <strong>Run Webhint</strong> -
+            Use <a href="https://webhint.io/">Webhint</a> to benchmark your sites performance and to get suggestions on how to further improve performance.
           </li>
         </ul>
         <h4>Other Performance</h4>
@@ -165,76 +151,24 @@
         </ul>
       </article>
 
-      <article>
-        <h3><span aria-hidden="true" class="fa fa-puzzle-piece"></span> Compatibility</h3>
-        <ul class="list-group">
-          <!--#if (IIS)-->
-          <li class="list-group-item">
-            <input name="Compatibility-OldIIS" type="checkbox"> <strong>IIS 7.5/8</strong> -
-            Some <em>web.config</em> settings do not exist in older versions of IIS (7.5 and 8). If you are using an older version, edit the <em>web.config</em> file and remove the <code>dynamicIpSecurity</code> settings.
-          </li>
-          <!--#endif-->
-        </ul>
-      </article>
-
-      <article>
-        <h3><span aria-hidden="true" class="fa fa-user"></span> Authentication &amp; Authorization</h3>
-        <ul class="list-group">
-          <li class="list-group-item">
-            <input name="Authentication-Provider" type="checkbox"> <strong>Choose Authentication Provider</strong> -
-            If you want no authentication, then you don't need to do anything. <strong>Do not</strong> build your own authentication provider unless you are a security expert, it is much harder than it looks and even professionals get it wrong. Choose from one of the options below:
-            <ol>
-              <li>IdentityServer4 - This is another site that handles all authentication with OAuth and Open ID Connect.</li>
-              <li>ASP.NET Identity - This is basically forms authentication with OAuth and Open ID Connect. This is what you get when you select 'Individual Account' from Microsoft's '<a href="http://i2.asp.net/media/47397/ConfigureAuthDialog.png?cdn_id=2015-05-22-001">Change Authentication</a>' dialogue, when you create a new Web Project. Follow <a href="http://www.asp.net/identity/overview/getting-started">this</a> tutorial. Don't forget to add the <code>NoLowercaseQueryStringAttribute</code> to the <code>AccountController</code> to enable the <code>RedirectToCanonicalUrlAttribute</code> to work (See comments on these classes for more information about what they do).</li>
-              <li>Windows Authentication - Follow <a href="http://www.asp.net/aspnet/overview/owin-and-katana/enabling-windows-authentication-in-katana">this</a> tutorial.</li>
-            </ol>
-          </li>
-        </ul>
-      </article>
-
+      <!--#if (ApplicationInsights)-->
       <article>
         <h3><span aria-hidden="true" class="fa fa-exclamation-triangle"></span> Resilience and Error Handling</h3>
         <ul class="list-group">
-
-          <li class="list-group-item">
-            <input name="ResilienceAndErrorHandling-DosProtection" type="checkbox"> <strong>Denial of Service (DoS) Protection</strong> -
-            There are a number of ways to protect your site from <a href="http://en.wikipedia.org/wiki/Denial-of-service_attack">Denial of Service (DoS)</a> attacks:
-            <ul>
-              <li>
-                <a href="https://www.cloudflare.com/">Cloudflare</a> - You can use the Cloudflare service as a proxy to your site. Cloudflare has sophisticated techniques to block attackers from accessing your site and is used by a large proportion of websites on the internet.
-              </li>
-              <!--#if (IIS)-->
-              <li>
-                <a href="http://www.iis.net/configreference/system.webserver/security/dynamicipsecurity">Dynamic IP Security</a> is a feature of IIS that can be configured using the <code>dynamicIpSecurity</code> section of the <em>web.config</em> file. Dynamic IP Security is set to logging only mode in this site, so IIS will log malicious requests from clients without actually rejecting them. If you decide to use this feature, run your site in this mode for some time and slowly raise the limits until you get no more 403.501 or 403.502 errors. Normal legitimate requests that can look like a DoS attack are:
-                <ol>
-                  <li>Google and Bing often make large numbers of requests that can look like a DoS attack and you do not want to block them by accident.</li>
-                  <li>Some organizations put themselves behind a proxy and their requests can look like they are from a single IP address.</li>
-                  <li>Pages on your site that cause a large number of requests to be made your site may trigger the Dynamic IP Security limits to be triggered and the page loading will be treated like a Denial of Service (DoS) attack.</li>
-                </ol>
-                You can test this feature by recording a request to your site using <a href="http://www.telerik.com/fiddler">Fiddler</a> and then replaying it many times.
-              </li>
-              <!--#endif-->
-            </ul>
-          </li>
-          <!--#if (ApplicationInsights)-->
           <li class="list-group-item">
             <input name="ResilienceAndErrorHandling-ApplicationInsights" type="checkbox"> <strong>Application Insights</strong> -
             Application Insights helps monitor your site and know about it when it goes down. Login to <a href="http://azure.microsoft.com">Azure</a>, create a new Application Insights instance, retrieve the Instrumentation Key and add it to your <em>appsettings.json</em> file. For more information see the <a href="http://docs.asp.net/en/latest/fundamentals/application-insights.html">Getting Started</a> guide.
           </li>
-          <!--#endif-->
-          <li class="list-group-item">
-            <input name="ResilienceAndErrorHandling-Logging" type="checkbox"> <strong>Add Logging</strong> -
-            This template comes with basic logging enabled in development mode. Consider using <a href="http://serilog.net/">Serilog</a> or another logging framework in production. Logging can be configured in <em>Startup.cs</em>.
-          </li>
         </ul>
       </article>
+      <!--#endif-->
 
       <article>
         <h3><span aria-hidden="true" class="fa fa-users"></span> Thank Developers</h3>
         <ul class="list-group">
           <li class="list-group-item">
-            <input name="ThankDevelopers-ConfigureHumansTxt" type="checkbox"> <strong>Configure Humans.txt</strong> -
-            Edit the <em>humans.txt</em> file at the root of the site. This is totally optional, you can delete this file if you want.
+            <input name="ThankDevelopers-ConfigureHumansTxt" type="checkbox"> <strong>Configure humans.txt</strong> -
+            <a href="http://humanstxt.org/">Humans.txt</a> is a standard way of describing and thanking the people that built your app. Edit the <em>humans.txt</em> file at the root of the app. This is totally optional, you can delete this file if you want.
             Be careful what you put into this file, you could give away clues about potential attack vectors on your site.
             Even giving contact details can be an attack vector (Most hackers manipulate people to get access).
           </li>
@@ -250,12 +184,7 @@
         <ul class="list-group">
           <li class="list-group-item">
             <input name="KeepingYourSiteUpToDate-KeepNuGetPackagesUpToDate" type="checkbox"> <strong>Keep NuGet Packages Up To Date</strong> -
-            Most updates can be easily carried out by simply updating <a href="https://www.nuget.org/">NuGet</a> packages. See <a href="https://docs.nuget.org/consume/package-manager-dialog">this</a> link for more information. However, there are a few things to watch out for before updating a package:
-            <ol>
-              <li>It's worth reading the NuGet package release notes to see what has changed and base the urgency of upgrading on this information. Blindly updating, can sometimes cause things to break. Sometimes packages are incompatible with other packages or there are special upgrade steps that need to be carried out.</li>
-              <li>When updating JavaScript or CSS framework Bower Packages, be careful that the particular version you are updating to is also available on the <a href="http://en.wikipedia.org/wiki/Content_delivery_network">CDN</a>. Some CDN's update more often than others. This project template uses the popular Google and Microsoft CDN's as it is likely that their scripts are already preloaded in a browsers cache. However, their CDN service also does not update too often.</li>
-              <li>You need to ensure that you update your JavaScript and CSS framework Bower packages when there are new versions to obtain security patches but also because <a href="http://en.wikipedia.org/wiki/Content_delivery_network">CDN</a>'s sometimes retire very old scripts. This template provides fallback scripts, so if a CDN does retire a script or goes down, it will use the scripts in this template instead. This will result in a slight performance degradation.</li>
-            </ol>
+            Most updates can be easily carried out by simply updating <a href="https://www.nuget.org/">NuGet</a> packages. See <a href="https://docs.nuget.org/consume/package-manager-dialog">this</a> link for more information.
           </li>
           <li class="list-group-item">
             <input name="KeepingYourSiteUpToDate-KeepTemplateUpToDate" type="checkbox"> <strong>Keep Template Up To Date</strong> -

--- a/Source/NuGetTemplate/.template.config/dotnetcli.host.json
+++ b/Source/NuGetTemplate/.template.config/dotnetcli.host.json
@@ -75,12 +75,6 @@
     },
     "GitHubActions": {
       "longName": "github-actions"
-    },
-    "SkipRestore": {
-      "longName": "no-restore"
-    },
-    "SkipOpenReadMe": {
-      "longName": "no-open-readme"
     }
   }
 }

--- a/Source/NuGetTemplate/.template.config/template.json
+++ b/Source/NuGetTemplate/.template.config/template.json
@@ -1,4 +1,3 @@
-// https://github.com/dotnet/templating/wiki/%22Runnable-Project%22-Templates#configuration
 {
   "$schema": "http://json.schemastore.org/template",
   "author": ".NET Boxed",
@@ -22,14 +21,12 @@
   "sources": [
     {
       "modifiers": [
-        // EditorConfig
         {
           "condition": "(!EditorConfig)",
           "exclude": [
             ".editorconfig"
           ]
         },
-        // GitHub
         {
           "condition": "(!GitHub)",
           "exclude": [
@@ -40,42 +37,36 @@
             ".github/SECURITY.md"
           ]
         },
-        // License
         {
           "condition": "(License == \"None\")",
           "exclude": [
             ".github/LICENSE.md"
           ]
         },
-        // ReadMe
         {
           "condition": "(!ReadMe)",
           "exclude": [
             "README.md"
           ]
         },
-        // Tests
         {
           "condition": "(!Tests)",
           "exclude": [
             "Tests/NuGetTemplate.Test/**/*"
           ]
         },
-        // AppVeyor
         {
           "condition": "(!AppVeyor)",
           "exclude": [
             "appveyor.yml"
           ]
         },
-        // AzurePipelines
         {
           "condition": "(!AzurePipelines)",
           "exclude": [
             "azure-pipelines.yml"
           ]
         },
-        // GitHubActions
         {
           "condition": "(!GitHubActions)",
           "exclude": [
@@ -89,7 +80,6 @@
     }
   ],
   "symbols": {
-    // Title
     "Title": {
       "type": "parameter",
       "datatype": "string",
@@ -103,7 +93,6 @@
       "valueSource": "Title",
       "valueTransform": "xmlEncode"
     },
-    // Description
     "Description": {
       "type": "parameter",
       "datatype": "string",
@@ -117,7 +106,6 @@
       "valueSource": "Description",
       "valueTransform": "xmlEncode"
     },
-    // Author
     "Author": {
       "type": "parameter",
       "datatype": "string",
@@ -131,7 +119,6 @@
       "valueSource": "Author",
       "valueTransform": "xmlEncode"
     },
-    // Tags
     "Tags": {
       "type": "parameter",
       "datatype": "string",
@@ -145,7 +132,6 @@
       "valueSource": "Tags",
       "valueTransform": "xmlEncode"
     },
-    // Contact
     "Contact": {
       "type": "parameter",
       "datatype": "string",
@@ -159,42 +145,36 @@
       "valueSource": "Contact",
       "valueTransform": "xmlEncode"
     },
-    // DotnetCore
     "DotnetCore": {
       "type": "parameter",
       "datatype": "bool",
       "defaultValue": "true",
       "description": "Sets .NET Core as one of the target frameworks."
     },
-    // DotnetFramework
     "DotnetFramework": {
       "type": "parameter",
       "datatype": "bool",
       "defaultValue": "false",
       "description": "Sets .NET Framework as one of the target frameworks."
     },
-    // Sign
     "Sign": {
       "type": "parameter",
       "datatype": "bool",
       "defaultValue": "true",
       "description": "Signs the NuGet package."
     },
-    // ReadMe
     "ReadMe": {
       "type": "parameter",
       "datatype": "bool",
       "defaultValue": "true",
       "description": "Add a README.md markdown file describing the project."
     },
-    // EditorConfig
     "EditorConfig": {
       "type": "parameter",
       "datatype": "bool",
       "defaultValue": "true",
       "description": "Add a .editorconfig file to set a fixed code style."
     },
-    // SourceControl
     "SourceControl": {
       "type": "parameter",
       "datatype": "choice",
@@ -247,7 +227,6 @@
       "type": "computed",
       "value": "(SourceControl == \"GitLab\")"
     },
-    // GitHubUsername
     "GitHubUsername": {
       "type": "parameter",
       "datatype": "string",
@@ -255,7 +234,6 @@
       "replaces": "GITHUB-USERNAME",
       "description": "Your GitHub username or organisation name that the project lives under."
     },
-    // GitHubProject
     "GitHubProject": {
       "type": "parameter",
       "datatype": "string",
@@ -263,7 +241,6 @@
       "replaces": "GITHUB-PROJECT",
       "description": "The name of your GitHub project."
     },
-    // License
     "License": {
       "type": "parameter",
       "datatype": "choice",
@@ -284,42 +261,36 @@
       "type": "computed",
       "value": "(License == \"MIT\")"
     },
-    // TreatWarningsAsErrors
     "TreatWarningsAsErrors": {
       "type": "parameter",
       "datatype": "bool",
       "defaultValue": "true",
       "description": "Treat warnings as errors."
     },
-    // StyleCop
     "StyleCop": {
       "type": "parameter",
       "datatype": "bool",
       "description": "Adds and enforces StyleCop analysers.",
       "defaultValue": "true"
     },
-    // Tests
     "Tests": {
       "type": "parameter",
       "datatype": "bool",
       "description": "Adds a unit test project.",
       "defaultValue": "true"
     },
-    // AppVeyor
     "AppVeyor": {
       "type": "parameter",
       "datatype": "bool",
       "description": "Adds AppVeyor continuous integration build file appveyor.yml.",
       "defaultValue": "false"
     },
-    // AzurePipelines
     "AzurePipelines": {
       "type": "parameter",
       "datatype": "bool",
       "description": "Adds Azure Pipelines continuous integration build file azure-pipelines.yml.",
       "defaultValue": "false"
     },
-    // GitHubActions
     "GitHubActions": {
       "type": "parameter",
       "datatype": "bool",
@@ -327,27 +298,13 @@
       "defaultValue": "true"
     },
 
-    // AuthoringMode
     "AuthoringMode": {
       "type": "generated",
       "generator": "constant",
       "parameters": {
-        "value": false
+        "value": "false"
       }
-    },
-    // https://github.com/dotnet/templating/wiki/Post-Action-Registry
-    "SkipRestore": {
-      "type": "parameter",
-      "datatype": "bool",
-      "description": "Skips the execution of 'dotnet restore' on project creation.",
-      "defaultValue": "false"
     }
-    //"SkipOpenToDo": {
-    //  "type": "parameter",
-    //  "datatype": "bool",
-    //  "description": "Skips opening the to-do list for the project in a web browser.",
-    //  "defaultValue": "false"
-    //}
   },
   "SpecialCustomOperations": {
     "**/*.md": {
@@ -484,25 +441,5 @@
         }
       ]
     }
-  },
-  "postActions": [
-    {
-      "actionId": "210D431B-A78B-4D2F-B762-4ED3E3EA9025",
-      "condition": "(!SkipRestore)",
-      "continueOnError": true,
-      "description": "Restore NuGet packages required by this project.",
-      "manualInstructions": [
-        { "text": "Run 'dotnet restore' in the directory the template was created in." }
-      ]
-    }
-    //{
-    //  "actionId": "FEA7469E-E2E7-4431-B86B-27EBC1744883",
-    //  "condition": "(!SkipOpenToDo)",
-    //  "continueOnError": true,
-    //  "description": "Open the to-do list for the project in a web browser.",
-    //  "manualInstructions": [
-    //    { "text": "Open the TODO.html in a web browser to see a to-do list." }
-    //  ]
-    //}
-  ]
+  }
 }

--- a/Source/OrleansTemplate/.template.config/dotnetcli.host.json
+++ b/Source/OrleansTemplate/.template.config/dotnetcli.host.json
@@ -64,14 +64,11 @@
     "GitHubActions": {
       "longName": "github-actions"
     },
-    "SkipRestore": {
-      "longName": "no-restore"
+    "SkipInstallAzureStorageEmulator": {
+      "longName": "no-install-storage-emulator"
     },
-    //"SkipOpenToDo": {
-    //  "longName": "no-open-todo"
-    //},
-    "SkipOpenAzureStorageEmulator": {
-      "longName": "no-storage-emulator"
+    "SkiStartAzureStorageEmulator": {
+      "longName": "no-start-storage-emulator"
     }
   }
 }

--- a/Source/OrleansTemplate/.template.config/template.json
+++ b/Source/OrleansTemplate/.template.config/template.json
@@ -1,4 +1,3 @@
-// https://github.com/dotnet/templating/wiki/%22Runnable-Project%22-Templates#configuration
 {
   "$schema": "http://json.schemastore.org/template",
   "author": ".NET Boxed",
@@ -15,7 +14,6 @@
   "sourceName": "OrleansTemplate",
   "preferNameDirectory": true,
   "guids": [
-    // User Secret ID
     "113f2d04-69f0-40c3-8797-ba3f356dd812"
   ],
   "primaryOutputs": [
@@ -24,14 +22,12 @@
   "sources": [
     {
       "modifiers": [
-        // EditorConfig
         {
           "condition": "(!EditorConfig)",
           "exclude": [
             ".editorconfig"
           ]
         },
-        // GitHub
         {
           "condition": "(!GitHub)",
           "exclude": [
@@ -42,14 +38,12 @@
             ".github/SECURITY.md"
           ]
         },
-        // ReadMe
         {
           "condition": "(!ReadMe)",
           "exclude": [
             "README.md"
           ]
         },
-        // HealthCheck
         {
           "condition": "(!HealthCheck)",
           "exclude": [
@@ -60,14 +54,12 @@
             "Source/OrleansTemplate.Server/Startup.cs"
           ]
         },
-        // IntegrationTest
         {
           "condition": "(!IntegrationTest)",
           "exclude": [
             "Tests/ApiTemplate.IntegrationTest/**/*"
           ]
         },
-        // Docker
         {
           "condition": "(!Docker)",
           "exclude": [
@@ -75,7 +67,6 @@
             ".dockerignore"
           ]
         },
-        // GitHubActions
         {
           "condition": "(!GitHubActions)",
           "exclude": [
@@ -89,7 +80,6 @@
     }
   ],
   "symbols": {
-    // Title
     "Title": {
       "type": "parameter",
       "datatype": "string",
@@ -103,7 +93,6 @@
       "valueSource": "Title",
       "valueTransform": "xmlEncode"
     },
-    // Description
     "Description": {
       "type": "parameter",
       "datatype": "string",
@@ -117,7 +106,6 @@
       "valueSource": "Description",
       "valueTransform": "xmlEncode"
     },
-    // Author
     "Author": {
       "type": "parameter",
       "datatype": "string",
@@ -131,7 +119,6 @@
       "valueSource": "Author",
       "valueTransform": "xmlEncode"
     },
-    // Contact
     "Contact": {
       "type": "parameter",
       "datatype": "string",
@@ -145,14 +132,12 @@
       "valueSource": "Contact",
       "valueTransform": "xmlEncode"
     },
-    // EditorConfig
     "EditorConfig": {
       "type": "parameter",
       "datatype": "bool",
       "defaultValue": "true",
       "description": "Add a .editorconfig file to set a fixed code style."
     },
-    // SourceControl
     "SourceControl": {
       "type": "parameter",
       "datatype": "choice",
@@ -173,7 +158,6 @@
       "type": "computed",
       "value": "(SourceControl == \"GitHub\")"
     },
-    // GitHubUsername
     "GitHubUsername": {
       "type": "parameter",
       "datatype": "string",
@@ -181,7 +165,6 @@
       "replaces": "GITHUB-USERNAME",
       "description": "Your GitHub username or organisation name that the project lives under."
     },
-    // GitHubProject
     "GitHubProject": {
       "type": "parameter",
       "datatype": "string",
@@ -189,21 +172,18 @@
       "replaces": "GITHUB-PROJECT",
       "description": "The name of your GitHub project."
     },
-    // ReadMe
     "ReadMe": {
       "type": "parameter",
       "datatype": "bool",
       "defaultValue": "true",
       "description": "Add a README.md markdown file describing the project."
     },
-    // TreatWarningsAsErrors
     "TreatWarningsAsErrors": {
       "type": "parameter",
       "datatype": "bool",
       "defaultValue": "true",
       "description": "Treat warnings as errors."
     },
-    // Analytics
     "Analytics": {
       "type": "parameter",
       "datatype": "choice",
@@ -224,14 +204,12 @@
       "type": "computed",
       "value": "(Analytics == \"Application Insights\")"
     },
-    // ApplicationInsightsKey
     "ApplicationInsightsKey": {
       "type": "parameter",
       "datatype": "string",
       "replaces": "APPLICATION-INSIGHTS-INSTRUMENTATION-KEY",
       "description": "Your Application Insights instrumentation key e.g. 11111111-2222-3333-4444-555555555555."
     },
-    // HealthCheck
     "HealthCheck": {
       "type": "parameter",
       "datatype": "bool",
@@ -262,7 +240,6 @@
       "description": "Adds an optimised Dockerfile to add the ability build a Docker image.",
       "defaultValue": "true"
     },
-    // GitHubActions
     "GitHubActions": {
       "type": "parameter",
       "datatype": "bool",
@@ -270,31 +247,23 @@
       "defaultValue": "true"
     },
 
-    // AuthoringMode
     "AuthoringMode": {
       "type": "generated",
       "generator": "constant",
       "parameters": {
-        "value": false
+        "value": "false"
       }
     },
-    // https://github.com/dotnet/templating/wiki/Post-Action-Registry
-    "SkipRestore": {
+    "SkipInstallAzureStorageEmulator": {
       "type": "parameter",
       "datatype": "bool",
-      "description": "Skips the execution of 'dotnet restore' on project creation.",
+      "description": "Skips the installation of the Azure Storage Emulator.",
       "defaultValue": "false"
     },
-    //"SkipOpenToDo": {
-    //  "type": "parameter",
-    //  "datatype": "bool",
-    //  "description": "Skips opening the to-do list for the project in a web browser.",
-    //  "defaultValue": "false"
-    //},
-    "SkipOpenAzureStorageEmulator": {
+    "SkiStartAzureStorageEmulator": {
       "type": "parameter",
       "datatype": "bool",
-      "description": "Skips the running of the Azure Storage Emulator.",
+      "description": "Skips the execution of the Azure Storage Emulator.",
       "defaultValue": "false"
     }
   },
@@ -436,31 +405,32 @@
   },
   "postActions": [
     {
-      "actionId": "210D431B-A78B-4D2F-B762-4ED3E3EA9025",
-      "condition": "(!SkipRestore)",
+      "actionId": "3A7C4B45-1F5D-4A30-959A-51B88E82B5D2",
+      "condition": "(!SkipInstallAzureStorageEmulator)",
       "continueOnError": true,
-      "description": "Restore NuGet packages required by this project.",
-      "manualInstructions": [
-        { "text": "Run 'dotnet restore' in the directory the template was created in." }
-      ]
+      "description ": "Install the Azure Storage Emulator where data is stored at development time.",
+      "args": {
+        "executable": "powershell.exe",
+        "args": "start https://docs.microsoft.com/en-us/azure/storage/common/storage-use-emulator",
+        "redirectStandardOutput": "false"
+      },
+      "manualInstructions": [{
+         "text": "Install the Azure Storage Emulator from https://docs.microsoft.com/en-us/azure/storage/common/storage-use-emulator."
+      }]
     },
-    //{
-    //  "actionId": "FEA7469E-E2E7-4431-B86B-27EBC1744883",
-    //  "condition": "(!SkipOpenToDo)",
-    //  "continueOnError": true,
-    //  "description": "Open the to-do list for the project in a web browser.",
-    //  "manualInstructions": [
-    //    { "text": "Open the TODO.html in a web browser to see a to-do list." }
-    //  ]
-    //},
     {
-      "actionId": "FEA7469E-E2E7-4431-B86B-27EBC1744883",
-      "condition": "(!SkipOpenAzureStorageEmulator)",
+      "actionId": "3A7C4B45-1F5D-4A30-959A-51B88E82B5D2",
+      "condition": "(!SkiStartAzureStorageEmulator)",
       "continueOnError": true,
-      "description": "Run the Azure Storage Emulator.",
-      "manualInstructions": [
-        { "text": "Run the Azure Storage Emulator (Download at https://docs.microsoft.com/en-us/azure/storage/common/storage-use-emulator)." }
-      ]
+      "description ": "Run the Azure Storage Emulator.",
+      "args": {
+        "executable": "C:\\Program Files (x86)\\Microsoft SDKs\\Azure\\Storage Emulator\\AzureStorageEmulator.exe",
+        "args": "start",
+        "redirectStandardOutput": "false"
+      },
+      "manualInstructions": [{
+         "text": "Run the Azure Storage Emulator."
+      }]
     }
   ]
 }

--- a/Tests/Boxed.Templates.FunctionalTest/ApiTemplateTest.cs
+++ b/Tests/Boxed.Templates.FunctionalTest/ApiTemplateTest.cs
@@ -1,7 +1,6 @@
 namespace Boxed.Templates.FunctionalTest
 {
     using System;
-    using System.Collections.Generic;
     using System.IO;
     using System.Linq;
     using System.Net;
@@ -19,6 +18,10 @@ namespace Boxed.Templates.FunctionalTest
     {
         private const string TemplateName = "api";
         private const string SolutionFileName = "ApiTemplate.sln";
+        private static readonly string[] DefaultArguments = new string[]
+        {
+            "no-open-todo=true",
+        };
 
         public ApiTemplateTest(ITestOutputHelper testOutputHelper)
         {
@@ -43,10 +46,9 @@ namespace Boxed.Templates.FunctionalTest
             await InstallTemplateAsync().ConfigureAwait(false);
             using (var tempDirectory = TempDirectory.NewTempDirectory())
             {
-                var dictionary = arguments
-                    .Select(x => x.Split('=', StringSplitOptions.RemoveEmptyEntries))
-                    .ToDictionary(x => x.First(), x => x.Last());
-                var project = await tempDirectory.DotnetNewAsync(TemplateName, name, dictionary).ConfigureAwait(false);
+                var project = await tempDirectory
+                    .DotnetNewAsync(TemplateName, name, DefaultArguments.ToArguments(arguments))
+                    .ConfigureAwait(false);
                 await project.DotnetRestoreAsync().ConfigureAwait(false);
                 await project.DotnetBuildAsync().ConfigureAwait(false);
                 await project.DotnetTestAsync().ConfigureAwait(false);
@@ -62,10 +64,9 @@ namespace Boxed.Templates.FunctionalTest
             await InstallTemplateAsync().ConfigureAwait(false);
             using (var tempDirectory = TempDirectory.NewTempDirectory())
             {
-                var dictionary = arguments
-                    .Select(x => x.Split('=', StringSplitOptions.RemoveEmptyEntries))
-                    .ToDictionary(x => x.First(), x => x.Last());
-                var project = await tempDirectory.DotnetNewAsync(TemplateName, name, dictionary).ConfigureAwait(false);
+                var project = await tempDirectory
+                    .DotnetNewAsync(TemplateName, name, DefaultArguments.ToArguments(arguments))
+                    .ConfigureAwait(false);
                 await project.DotnetToolRestoreAsync().ConfigureAwait(false);
                 await project.DotnetCakeAsync(timeout: TimeSpan.FromMinutes(5)).ConfigureAwait(false);
             }
@@ -168,10 +169,7 @@ namespace Boxed.Templates.FunctionalTest
                     .DotnetNewAsync(
                         TemplateName,
                         "ApiHealthCheckFalse",
-                        new Dictionary<string, string>()
-                        {
-                            { "health-check", "false" },
-                        })
+                        DefaultArguments.ToArguments(new string[] { "health-check=false" }))
                     .ConfigureAwait(false);
                 await project.DotnetRestoreAsync().ConfigureAwait(false);
                 await project.DotnetBuildAsync().ConfigureAwait(false);
@@ -208,10 +206,7 @@ namespace Boxed.Templates.FunctionalTest
                     .DotnetNewAsync(
                         TemplateName,
                         "ApiHttpsEverywhereFalse",
-                        new Dictionary<string, string>()
-                        {
-                            { "https-everywhere", "false" },
-                        })
+                        DefaultArguments.ToArguments(new string[] { "https-everywhere=false" }))
                     .ConfigureAwait(false);
                 await project.DotnetRestoreAsync().ConfigureAwait(false);
                 await project.DotnetBuildAsync().ConfigureAwait(false);
@@ -249,10 +244,7 @@ namespace Boxed.Templates.FunctionalTest
                     .DotnetNewAsync(
                         TemplateName,
                         "ApiSwaggerFalse",
-                        new Dictionary<string, string>()
-                        {
-                            { "swagger", "false" },
-                        })
+                        DefaultArguments.ToArguments(new string[] { "swagger=false" }))
                     .ConfigureAwait(false);
                 await project.DotnetRestoreAsync().ConfigureAwait(false);
                 await project.DotnetBuildAsync().ConfigureAwait(false);
@@ -284,10 +276,7 @@ namespace Boxed.Templates.FunctionalTest
                     .DotnetNewAsync(
                         TemplateName,
                         "ApiDockerFalse",
-                        new Dictionary<string, string>()
-                        {
-                            { "docker", "false" },
-                        })
+                        DefaultArguments.ToArguments(new string[] { "docker=false" }))
                     .ConfigureAwait(false);
                 await project.DotnetRestoreAsync().ConfigureAwait(false);
                 await project.DotnetBuildAsync().ConfigureAwait(false);

--- a/Tests/Boxed.Templates.FunctionalTest/EnumerableExtensions.cs
+++ b/Tests/Boxed.Templates.FunctionalTest/EnumerableExtensions.cs
@@ -1,0 +1,20 @@
+namespace Boxed.Templates.FunctionalTest
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+
+    public static class EnumerableExtensions
+    {
+        public static IDictionary<string, string> ToArguments(this string[] arguments) =>
+            arguments
+                .Select(x => x.Split('=', StringSplitOptions.RemoveEmptyEntries))
+                .ToDictionary(x => x.First(), x => x.Last());
+
+        public static IDictionary<string, string> ToArguments(this string[] arguments1, string[] arguments2) =>
+            arguments1
+                .Concat(arguments2)
+                .Select(x => x.Split('=', StringSplitOptions.RemoveEmptyEntries))
+                .ToDictionary(x => x.First(), x => x.Last());
+    }
+}

--- a/Tests/Boxed.Templates.FunctionalTest/GraphQLTemplateTest.cs
+++ b/Tests/Boxed.Templates.FunctionalTest/GraphQLTemplateTest.cs
@@ -1,7 +1,6 @@
 namespace Boxed.Templates.FunctionalTest
 {
     using System;
-    using System.Collections.Generic;
     using System.IO;
     using System.Linq;
     using System.Net;
@@ -18,6 +17,10 @@ namespace Boxed.Templates.FunctionalTest
     {
         private const string TemplateName = "graphql";
         private const string SolutionFileName = "GraphQLTemplate.sln";
+        private static readonly string[] DefaultArguments = new string[]
+        {
+            "no-open-todo=true",
+        };
 
         public GraphQLTemplateTest(ITestOutputHelper testOutputHelper)
         {
@@ -42,10 +45,9 @@ namespace Boxed.Templates.FunctionalTest
             await InstallTemplateAsync().ConfigureAwait(false);
             using (var tempDirectory = TempDirectory.NewTempDirectory())
             {
-                var dictionary = arguments
-                    .Select(x => x.Split('=', StringSplitOptions.RemoveEmptyEntries))
-                    .ToDictionary(x => x.First(), x => x.Last());
-                var project = await tempDirectory.DotnetNewAsync(TemplateName, name, dictionary).ConfigureAwait(false);
+                var project = await tempDirectory
+                    .DotnetNewAsync(TemplateName, name, DefaultArguments.ToArguments(arguments))
+                    .ConfigureAwait(false);
                 await project.DotnetRestoreAsync().ConfigureAwait(false);
                 await project.DotnetBuildAsync().ConfigureAwait(false);
                 await project.DotnetTestAsync().ConfigureAwait(false);
@@ -61,10 +63,9 @@ namespace Boxed.Templates.FunctionalTest
             await InstallTemplateAsync().ConfigureAwait(false);
             using (var tempDirectory = TempDirectory.NewTempDirectory())
             {
-                var dictionary = arguments
-                    .Select(x => x.Split('=', StringSplitOptions.RemoveEmptyEntries))
-                    .ToDictionary(x => x.First(), x => x.Last());
-                var project = await tempDirectory.DotnetNewAsync(TemplateName, name, dictionary).ConfigureAwait(false);
+                var project = await tempDirectory
+                    .DotnetNewAsync(TemplateName, name, DefaultArguments.ToArguments(arguments))
+                    .ConfigureAwait(false);
                 await project.DotnetToolRestoreAsync().ConfigureAwait(false);
                 await project.DotnetCakeAsync(timeout: TimeSpan.FromMinutes(5)).ConfigureAwait(false);
             }
@@ -139,10 +140,7 @@ namespace Boxed.Templates.FunctionalTest
                     .DotnetNewAsync(
                         TemplateName,
                         "GraphQLTHealthCheckFalse",
-                        new Dictionary<string, string>()
-                        {
-                            { "health-check", "false" },
-                        })
+                        DefaultArguments.ToArguments(new string[] { "health-check=false" }))
                     .ConfigureAwait(false);
                 await project.DotnetRestoreAsync().ConfigureAwait(false);
                 await project.DotnetBuildAsync().ConfigureAwait(false);
@@ -210,10 +208,7 @@ namespace Boxed.Templates.FunctionalTest
                     .DotnetNewAsync(
                         TemplateName,
                         "GraphQLTHttpsEverywhereFalse",
-                        new Dictionary<string, string>()
-                        {
-                            { "https-everywhere", "false" },
-                        })
+                        DefaultArguments.ToArguments(new string[] { "https-everywhere=false" }))
                     .ConfigureAwait(false);
                 await project.DotnetRestoreAsync().ConfigureAwait(false);
                 await project.DotnetBuildAsync().ConfigureAwait(false);
@@ -251,10 +246,7 @@ namespace Boxed.Templates.FunctionalTest
                     .DotnetNewAsync(
                         TemplateName,
                         "GraphQLTAuthorizationTrue",
-                        new Dictionary<string, string>()
-                        {
-                            { "authorization", "true" },
-                        })
+                        DefaultArguments.ToArguments(new string[] { "authorization=true" }))
                     .ConfigureAwait(false);
                 await project.DotnetRestoreAsync().ConfigureAwait(false);
                 await project.DotnetBuildAsync().ConfigureAwait(false);
@@ -295,10 +287,7 @@ namespace Boxed.Templates.FunctionalTest
                     .DotnetNewAsync(
                         TemplateName,
                         "GraphQLTAuthorizationFalse",
-                        new Dictionary<string, string>()
-                        {
-                            { "authorization", "false" },
-                        })
+                        DefaultArguments.ToArguments(new string[] { "authorization=false" }))
                     .ConfigureAwait(false);
                 await project.DotnetRestoreAsync().ConfigureAwait(false);
                 await project.DotnetBuildAsync().ConfigureAwait(false);
@@ -331,10 +320,7 @@ namespace Boxed.Templates.FunctionalTest
                     .DotnetNewAsync(
                         TemplateName,
                         "GraphQLDockerFalse",
-                        new Dictionary<string, string>()
-                        {
-                            { "docker", "false" },
-                        })
+                        DefaultArguments.ToArguments(new string[] { "docker=false" }))
                     .ConfigureAwait(false);
                 await project.DotnetRestoreAsync().ConfigureAwait(false);
                 await project.DotnetBuildAsync().ConfigureAwait(false);

--- a/Tests/Boxed.Templates.FunctionalTest/NuGetTemplateTest.cs
+++ b/Tests/Boxed.Templates.FunctionalTest/NuGetTemplateTest.cs
@@ -1,7 +1,6 @@
 namespace Boxed.Templates.FunctionalTest
 {
     using System;
-    using System.Collections.Generic;
     using System.IO;
     using System.Linq;
     using System.Threading.Tasks;
@@ -37,10 +36,9 @@ namespace Boxed.Templates.FunctionalTest
             await InstallTemplateAsync().ConfigureAwait(false);
             using (var tempDirectory = TempDirectory.NewTempDirectory())
             {
-                var dictionary = arguments
-                    .Select(x => x.Split('=', StringSplitOptions.RemoveEmptyEntries))
-                    .ToDictionary(x => x.First(), x => x.Last());
-                var project = await tempDirectory.DotnetNewAsync(TemplateName, name, dictionary).ConfigureAwait(false);
+                var project = await tempDirectory
+                    .DotnetNewAsync(TemplateName, name, arguments.ToArguments())
+                    .ConfigureAwait(false);
                 await project.DotnetRestoreAsync().ConfigureAwait(false);
                 await project.DotnetBuildAsync().ConfigureAwait(false);
 
@@ -62,10 +60,9 @@ namespace Boxed.Templates.FunctionalTest
             await InstallTemplateAsync().ConfigureAwait(false);
             using (var tempDirectory = TempDirectory.NewTempDirectory())
             {
-                var dictionary = arguments
-                    .Select(x => x.Split('=', StringSplitOptions.RemoveEmptyEntries))
-                    .ToDictionary(x => x.First(), x => x.Last());
-                var project = await tempDirectory.DotnetNewAsync(TemplateName, name, dictionary).ConfigureAwait(false);
+                var project = await tempDirectory
+                    .DotnetNewAsync(TemplateName, name, arguments.ToArguments())
+                    .ConfigureAwait(false);
                 await project.DotnetToolRestoreAsync().ConfigureAwait(false);
                 await project.DotnetCakeAsync().ConfigureAwait(false);
             }
@@ -86,10 +83,9 @@ namespace Boxed.Templates.FunctionalTest
             await InstallTemplateAsync().ConfigureAwait(false);
             using (var tempDirectory = TempDirectory.NewTempDirectory())
             {
-                var dictionary = arguments
-                    .Select(x => x.Split('=', StringSplitOptions.RemoveEmptyEntries))
-                    .ToDictionary(x => x.First(), x => x.Last());
-                var project = await tempDirectory.DotnetNewAsync(TemplateName, name, dictionary).ConfigureAwait(false);
+                var project = await tempDirectory
+                    .DotnetNewAsync(TemplateName, name, arguments.ToArguments())
+                    .ConfigureAwait(false);
                 await project.DotnetRestoreAsync().ConfigureAwait(false);
                 await project.DotnetBuildAsync().ConfigureAwait(false);
                 await project.DotnetTestAsync().ConfigureAwait(false);
@@ -114,10 +110,7 @@ namespace Boxed.Templates.FunctionalTest
                     .DotnetNewAsync(
                         TemplateName,
                         "NuGetSignFalse",
-                        new Dictionary<string, string>()
-                        {
-                            { "sign", "false" },
-                        })
+                        new string[] { "sign=false" }.ToArguments())
                     .ConfigureAwait(false);
                 await project.DotnetRestoreAsync().ConfigureAwait(false);
                 await project.DotnetBuildAsync().ConfigureAwait(false);

--- a/Tests/Boxed.Templates.FunctionalTest/OrleansTemplateTest.cs
+++ b/Tests/Boxed.Templates.FunctionalTest/OrleansTemplateTest.cs
@@ -1,7 +1,6 @@
 namespace Boxed.Templates.FunctionalTest
 {
     using System;
-    using System.Linq;
     using System.Threading.Tasks;
     using Boxed.DotnetNewTest;
     using Xunit;
@@ -12,6 +11,11 @@ namespace Boxed.Templates.FunctionalTest
     {
         private const string TemplateName = "orleans";
         private const string SolutionFileName = "OrleansTemplate.sln";
+        private static readonly string[] DefaultArguments = new string[]
+        {
+            "no-install-storage-emulator=true",
+            "no-start-storage-emulator=true",
+        };
 
         public OrleansTemplateTest(ITestOutputHelper testOutputHelper)
         {
@@ -34,10 +38,9 @@ namespace Boxed.Templates.FunctionalTest
             await InstallTemplateAsync().ConfigureAwait(false);
             using (var tempDirectory = TempDirectory.NewTempDirectory())
             {
-                var dictionary = arguments
-                    .Select(x => x.Split('=', StringSplitOptions.RemoveEmptyEntries))
-                    .ToDictionary(x => x.First(), x => x.Last());
-                var project = await tempDirectory.DotnetNewAsync(TemplateName, name, dictionary).ConfigureAwait(false);
+                var project = await tempDirectory
+                    .DotnetNewAsync(TemplateName, name, DefaultArguments.ToArguments(arguments))
+                    .ConfigureAwait(false);
                 await project.DotnetRestoreAsync().ConfigureAwait(false);
                 await project.DotnetBuildAsync().ConfigureAwait(false);
             }
@@ -53,10 +56,9 @@ namespace Boxed.Templates.FunctionalTest
             await InstallTemplateAsync().ConfigureAwait(false);
             using (var tempDirectory = TempDirectory.NewTempDirectory())
             {
-                var dictionary = arguments
-                    .Select(x => x.Split('=', StringSplitOptions.RemoveEmptyEntries))
-                    .ToDictionary(x => x.First(), x => x.Last());
-                var project = await tempDirectory.DotnetNewAsync(TemplateName, name, dictionary).ConfigureAwait(false);
+                var project = await tempDirectory
+                    .DotnetNewAsync(TemplateName, name, DefaultArguments.ToArguments(arguments))
+                    .ConfigureAwait(false);
                 await project.DotnetToolRestoreAsync().ConfigureAwait(false);
                 await project.DotnetCakeAsync(timeout: TimeSpan.FromMinutes(5)).ConfigureAwait(false);
             }


### PR DESCRIPTION
- API and GraphQL Templates now open `TODO.html` after project creation.
- Rewrote API and GraphQL Templates `TODO.html`.
- Removed post actions from all templates that restore NuGet packages.
- Added post actions to Orleans template to install and start the Azure Storage Emulator.
- Removed all comments from `template.json` files.
