### PR TITLE
Fix Building & Pushing Docker Images

### DIFF
--- a/Source/ApiTemplate/.github/workflows/build.yml
+++ b/Source/ApiTemplate/.github/workflows/build.yml
@@ -83,13 +83,13 @@ jobs:
     - name: 'Install Docker BuildX'
       uses: docker/setup-buildx-action@v1
     - name: 'Docker Login'
-      if: github.ref == 'refs/heads/main'
+      if: github.ref == 'refs/heads/main' || github.event_name == 'release'
       env:
         DOCKER_USERNAME: ${{secrets.DOCKER_USERNAME}}
         DOCKER_PASSWORD: ${{secrets.DOCKER_PASSWORD}}
       run: echo $env:DOCKER_PASSWORD | docker login --username "$($env:DOCKER_USERNAME)" --password-stdin
       shell: pwsh
     - name: 'Dotnet Cake DockerBuild'
-      run: dotnet cake --target=DockerBuild --tag=${{secrets.DOCKER_USERNAME}}/apitemplate --push=${{github.ref == 'refs/heads/main'}}
+      run: dotnet cake --target=DockerBuild --tag=${{secrets.DOCKER_USERNAME}}/apitemplate --push=${{github.ref == 'refs/heads/main' || github.event_name == 'release'}}
       shell: pwsh
 #endif

--- a/Source/ApiTemplate/Source/ApiTemplate/Dockerfile
+++ b/Source/ApiTemplate/Source/ApiTemplate/Dockerfile
@@ -4,7 +4,7 @@
 # docker buildx build --progress plain --file "Source\ApiTemplate\Dockerfile" --tag api .
 
 # SDK image used to build and publish the application
-FROM mcr.microsoft.com/dotnet/sdk:5.0-alpine AS sdk
+FROM mcr.microsoft.com/dotnet/sdk:5.0 AS sdk
 # To use the debug build configuration pass --build-arg Configuration=Debug
 ARG Configuration=Release
 ENV DOTNET_CLI_TELEMETRY_OPTOUT=true \

--- a/Source/GraphQLTemplate/.github/workflows/build.yml
+++ b/Source/GraphQLTemplate/.github/workflows/build.yml
@@ -83,13 +83,13 @@ jobs:
     - name: 'Install Docker BuildX'
       uses: docker/setup-buildx-action@v1
     - name: 'Docker Login'
-      if: github.ref == 'refs/heads/main'
+      if: github.ref == 'refs/heads/main' || github.event_name == 'release'
       env:
         DOCKER_USERNAME: ${{secrets.DOCKER_USERNAME}}
         DOCKER_PASSWORD: ${{secrets.DOCKER_PASSWORD}}
       run: echo $env:DOCKER_PASSWORD | docker login --username "$($env:DOCKER_USERNAME)" --password-stdin
       shell: pwsh
     - name: 'Dotnet Cake DockerBuild'
-      run: dotnet cake --target=DockerBuild --tag=${{secrets.DOCKER_USERNAME}}/graphqltemplate --push=${{github.ref == 'refs/heads/main'}}
+      run: dotnet cake --target=DockerBuild --tag=${{secrets.DOCKER_USERNAME}}/graphqltemplate --push=${{github.ref == 'refs/heads/main' || github.event_name == 'release'}}
       shell: pwsh
 #endif

--- a/Source/GraphQLTemplate/Source/GraphQLTemplate/Dockerfile
+++ b/Source/GraphQLTemplate/Source/GraphQLTemplate/Dockerfile
@@ -4,7 +4,7 @@
 # docker buildx build --progress plain --file "Source\GraphQLTemplate\Dockerfile" --tag graph .
 
 # SDK image used to build and publish the application
-FROM mcr.microsoft.com/dotnet/sdk:5.0-alpine AS sdk
+FROM mcr.microsoft.com/dotnet/sdk:5.0 AS sdk
 # To use the debug build configuration pass --build-arg Configuration=Debug
 ARG Configuration=Release
 ENV DOTNET_CLI_TELEMETRY_OPTOUT=true \

--- a/Source/OrleansTemplate/.github/workflows/build.yml
+++ b/Source/OrleansTemplate/.github/workflows/build.yml
@@ -83,13 +83,13 @@ jobs:
     - name: 'Install Docker BuildX'
       uses: docker/setup-buildx-action@v1
     - name: 'Docker Login'
-      if: github.ref == 'refs/heads/main'
+      if: github.ref == 'refs/heads/main' || github.event_name == 'release'
       env:
         DOCKER_USERNAME: ${{secrets.DOCKER_USERNAME}}
         DOCKER_PASSWORD: ${{secrets.DOCKER_PASSWORD}}
       run: echo $env:DOCKER_PASSWORD | docker login --username "$($env:DOCKER_USERNAME)" --password-stdin
       shell: pwsh
     - name: 'Dotnet Cake DockerBuild'
-      run: dotnet cake --target=DockerBuild --tag=${{secrets.DOCKER_USERNAME}}/orleanstemplate --push=${{github.ref == 'refs/heads/main'}}
+      run: dotnet cake --target=DockerBuild --tag=${{secrets.DOCKER_USERNAME}}/orleanstemplate --push=${{github.ref == 'refs/heads/main' || github.event_name == 'release'}}
       shell: pwsh
 #endif

--- a/Source/OrleansTemplate/Source/OrleansTemplate.Server/Dockerfile
+++ b/Source/OrleansTemplate/Source/OrleansTemplate.Server/Dockerfile
@@ -4,7 +4,7 @@
 # docker buildx build --progress plain --file "Source\OrleansTemplate.Server\Dockerfile" --tag orleans .
 
 # SDK image used to build and publish the application
-FROM mcr.microsoft.com/dotnet/sdk:5.0-alpine AS sdk
+FROM mcr.microsoft.com/dotnet/sdk:5.0 AS sdk
 # To use the debug build configuration pass --build-arg Configuration=Debug
 ARG Configuration=Release
 ENV DOTNET_CLI_TELEMETRY_OPTOUT=true \


### PR DESCRIPTION
- Push docker images on GitHub releases and not just on changes pushed to the main branch.
- Use full SDK image for ARM64 support. The alpine image does not currently support ARM64 but will in .NET 6.