### PR TITLE
Enable <Nullable> in ApiTemplate project.

### DIFF
--- a/Source/ApiTemplate/Directory.Build.props
+++ b/Source/ApiTemplate/Directory.Build.props
@@ -13,6 +13,7 @@
     <EnforceCodeStyleInBuild Condition="'$(EditorConfig)' == 'true'">true</EnforceCodeStyleInBuild>
     <AnalysisLevel>latest</AnalysisLevel>
     <TreatWarningsAsErrors Condition="'$(TreatWarningsAsErrors)' == 'true'">true</TreatWarningsAsErrors>
+    <Nullable>enable</Nullable>
   </PropertyGroup>
 
   <PropertyGroup Label="Versioning">

--- a/Source/ApiTemplate/Source/ApiTemplate/ApplicationBuilderExtensions.cs
+++ b/Source/ApiTemplate/Source/ApiTemplate/ApplicationBuilderExtensions.cs
@@ -113,10 +113,10 @@ namespace ApiTemplate
                 options =>
                 {
                     // Set the Swagger UI browser document title.
-                    options.DocumentTitle = typeof(Startup)
-                        .Assembly
-                        .GetCustomAttribute<AssemblyProductAttribute>()
-                        .Product;
+                    var assembly = typeof(Startup).Assembly;
+                    options.DocumentTitle = assembly!
+                        .GetCustomAttribute<AssemblyProductAttribute>()?
+                         .Product;
                     // Set the Swagger UI to render at '/'.
                     options.RoutePrefix = string.Empty;
 
@@ -125,6 +125,11 @@ namespace ApiTemplate
 
 #if Versioning
                     var provider = application.ApplicationServices.GetService<IApiVersionDescriptionProvider>();
+                    if (provider is null)
+                    {
+                        throw new Exception($"{nameof(IApiVersionDescriptionProvider)} service is null.");
+                    }
+
                     foreach (var apiVersionDescription in provider
                         .ApiVersionDescriptions
                         .OrderByDescending(x => x.ApiVersion))

--- a/Source/ApiTemplate/Source/ApiTemplate/Commands/GetCarPageCommand.cs
+++ b/Source/ApiTemplate/Source/ApiTemplate/Commands/GetCarPageCommand.cs
@@ -72,41 +72,41 @@ namespace ApiTemplate.Commands
                     HasNextPage = hasNextPage,
                     HasPreviousPage = hasPreviousPage,
                     NextPageUrl = hasNextPage ? new Uri(this.linkGenerator.GetUriByRouteValues(
-                        this.httpContextAccessor.HttpContext,
+                        this.httpContextAccessor.HttpContext!,
                         CarsControllerRoute.GetCarPage,
                         new PageOptions()
                         {
                             First = pageOptions.First ?? pageOptions.Last,
                             After = endCursor,
-                        })) : null,
+                        })!) : null,
                     PreviousPageUrl = hasPreviousPage ? new Uri(this.linkGenerator.GetUriByRouteValues(
-                        this.httpContextAccessor.HttpContext,
+                        this.httpContextAccessor.HttpContext!,
                         CarsControllerRoute.GetCarPage,
                         new PageOptions()
                         {
                             Last = pageOptions.First ?? pageOptions.Last,
                             Before = startCursor,
-                        })) : null,
+                        })!) : null,
                     FirstPageUrl = new Uri(this.linkGenerator.GetUriByRouteValues(
-                        this.httpContextAccessor.HttpContext,
+                        this.httpContextAccessor.HttpContext!,
                         CarsControllerRoute.GetCarPage,
                         new PageOptions()
                         {
                             First = pageOptions.First ?? pageOptions.Last,
-                        })),
+                        })!),
                     LastPageUrl = new Uri(this.linkGenerator.GetUriByRouteValues(
-                        this.httpContextAccessor.HttpContext,
+                        this.httpContextAccessor.HttpContext!,
                         CarsControllerRoute.GetCarPage,
                         new PageOptions()
                         {
                             Last = pageOptions.First ?? pageOptions.Last,
-                        })),
+                        })!),
                 },
                 TotalCount = totalCount,
             };
             connection.Items.AddRange(carViewModels);
 
-            this.httpContextAccessor.HttpContext.Response.Headers.Add(
+            this.httpContextAccessor.HttpContext!.Response.Headers.Add(
                 LinkHttpHeaderName,
                 connection.PageInfo.ToLinkHttpHeaderValue());
 

--- a/Source/ApiTemplate/Source/ApiTemplate/CustomServiceCollectionExtensions.cs
+++ b/Source/ApiTemplate/Source/ApiTemplate/CustomServiceCollectionExtensions.cs
@@ -240,7 +240,7 @@ namespace ApiTemplate
                                         activity.AddTag(OpenTelemetryAttributeName.Http.RequestContentType, request.ContentType);
 
                                         var user = context.User;
-                                        if (user.Identity.Name is not null)
+                                        if (user.Identity?.Name is not null)
                                         {
                                             activity.AddTag(OpenTelemetryAttributeName.EndUser.Id, user.Identity.Name);
                                             activity.AddTag(OpenTelemetryAttributeName.EndUser.Scope, string.Join(',', user.Claims.Select(x => x.Value)));
@@ -300,8 +300,8 @@ namespace ApiTemplate
                 options =>
                 {
                     var assembly = typeof(Startup).Assembly;
-                    var assemblyProduct = assembly.GetCustomAttribute<AssemblyProductAttribute>().Product;
-                    var assemblyDescription = assembly.GetCustomAttribute<AssemblyDescriptionAttribute>().Description;
+                    var assemblyProduct = assembly!.GetCustomAttribute<AssemblyProductAttribute>()?.Product ?? "{Assembly-Product-Placeholder}";
+                    var assemblyDescription = assembly!.GetCustomAttribute<AssemblyDescriptionAttribute>()?.Description ?? "{Assembly-Description-Placeholder}";
 
                     options.DescribeAllParametersInCamelCase();
                     options.EnableAnnotations();

--- a/Source/ApiTemplate/Source/ApiTemplate/Mappers/CarToCarMapper.cs
+++ b/Source/ApiTemplate/Source/ApiTemplate/Mappers/CarToCarMapper.cs
@@ -37,9 +37,9 @@ namespace ApiTemplate.Mappers
             destination.Make = source.Make;
             destination.Model = source.Model;
             destination.Url = new Uri(this.linkGenerator.GetUriByRouteValues(
-                this.httpContextAccessor.HttpContext,
+                this.httpContextAccessor.HttpContext!,
                 CarsControllerRoute.GetCar,
-                new { source.CarId }));
+                new { source.CarId })!);
         }
     }
 }

--- a/Source/ApiTemplate/Source/ApiTemplate/Models/Car.cs
+++ b/Source/ApiTemplate/Source/ApiTemplate/Models/Car.cs
@@ -10,9 +10,9 @@
 
         public int Cylinders { get; set; }
 
-        public string Make { get; set; }
+        public string Make { get; set; } = default!;
 
-        public string Model { get; set; }
+        public string Model { get; set; } = default!;
 
         public DateTimeOffset Modified { get; set; }
     }

--- a/Source/ApiTemplate/Source/ApiTemplate/Options/ApplicationOptions.cs
+++ b/Source/ApiTemplate/Source/ApiTemplate/Options/ApplicationOptions.cs
@@ -20,18 +20,18 @@ namespace ApiTemplate.Options
 
 #if ResponseCompression
         [Required]
-        public CompressionOptions Compression { get; set; }
+        public CompressionOptions Compression { get; set; } = default!;
 
 #endif
 #if ForwardedHeaders
         [Required]
-        public ForwardedHeadersOptions ForwardedHeaders { get; set; }
+        public ForwardedHeadersOptions ForwardedHeaders { get; set; } = default!;
 
 #elif HostFiltering
         [Required]
-        public HostFilteringOptions HostFiltering { get; set; }
+        public HostFilteringOptions HostFiltering { get; set; } = default!;
 
 #endif
-        public KestrelServerOptions Kestrel { get; set; }
+        public KestrelServerOptions Kestrel { get; set; } = default!;
     }
 }

--- a/Source/ApiTemplate/Source/ApiTemplate/Program.cs
+++ b/Source/ApiTemplate/Source/ApiTemplate/Program.cs
@@ -28,7 +28,7 @@ namespace ApiTemplate
             }
 
             var hostEnvironment = host.Services.GetRequiredService<IHostEnvironment>();
-            hostEnvironment.ApplicationName = Assembly.GetExecutingAssembly().GetCustomAttribute<AssemblyProductAttribute>().Product;
+            hostEnvironment.ApplicationName = Assembly.GetExecutingAssembly()?.GetCustomAttribute<AssemblyProductAttribute>()?.Product;
 
             Log.Logger = CreateLogger(host);
 

--- a/Source/ApiTemplate/Source/ApiTemplate/Repositories/CarRepository.cs
+++ b/Source/ApiTemplate/Source/ApiTemplate/Repositories/CarRepository.cs
@@ -16,7 +16,7 @@ namespace ApiTemplate.Repositories
                 CarId = 1,
                 Created = DateTimeOffset.UtcNow.AddDays(-8),
                 Cylinders = 8,
-                Make = "Lambourghini",
+                Make = "Lamborghini",
                 Model = "Countach",
                 Modified = DateTimeOffset.UtcNow.AddDays(-8),
             },
@@ -89,7 +89,7 @@ namespace ApiTemplate.Repositories
             return Task.CompletedTask;
         }
 
-        public Task<Car> GetAsync(int carId, CancellationToken cancellationToken)
+        public Task<Car?> GetAsync(int carId, CancellationToken cancellationToken)
         {
             var car = Cars.FirstOrDefault(x => x.CarId == carId);
             return Task.FromResult(car);
@@ -102,9 +102,9 @@ namespace ApiTemplate.Repositories
             CancellationToken cancellationToken) =>
             Task.FromResult(Cars
                 .OrderBy(x => x.Created)
-                .If(createdAfter.HasValue, x => x.Where(y => y.Created > createdAfter.Value))
-                .If(createdBefore.HasValue, x => x.Where(y => y.Created < createdBefore.Value))
-                .If(first.HasValue, x => x.Take(first.Value))
+                .If(createdAfter.HasValue, x => x.Where(y => y.Created > createdAfter!.Value))
+                .If(createdBefore.HasValue, x => x.Where(y => y.Created < createdBefore!.Value))
+                .If(first.HasValue, x => x.Take(first!.Value))
                 .ToList());
 
         public Task<List<Car>> GetCarsReverseAsync(
@@ -114,9 +114,9 @@ namespace ApiTemplate.Repositories
             CancellationToken cancellationToken) =>
             Task.FromResult(Cars
                 .OrderBy(x => x.Created)
-                .If(createdAfter.HasValue, x => x.Where(y => y.Created > createdAfter.Value))
-                .If(createdBefore.HasValue, x => x.Where(y => y.Created < createdBefore.Value))
-                .If(last.HasValue, x => x.TakeLast(last.Value))
+                .If(createdAfter.HasValue, x => x.Where(y => y.Created > createdAfter!.Value))
+                .If(createdBefore.HasValue, x => x.Where(y => y.Created < createdBefore!.Value))
+                .If(last.HasValue, x => x.TakeLast(last!.Value))
                 .ToList());
 
         public Task<bool> GetHasNextPageAsync(
@@ -125,8 +125,8 @@ namespace ApiTemplate.Repositories
             CancellationToken cancellationToken) =>
             Task.FromResult(Cars
                 .OrderBy(x => x.Created)
-                .If(createdAfter.HasValue, x => x.Where(y => y.Created > createdAfter.Value))
-                .Skip(first.Value)
+                .If(createdAfter.HasValue, x => x.Where(y => y.Created > createdAfter!.Value))
+                .If(first.HasValue, x => x.Skip(first!.Value))
                 .Any());
 
         public Task<bool> GetHasPreviousPageAsync(
@@ -135,8 +135,8 @@ namespace ApiTemplate.Repositories
             CancellationToken cancellationToken) =>
             Task.FromResult(Cars
                 .OrderBy(x => x.Created)
-                .If(createdBefore.HasValue, x => x.Where(y => y.Created < createdBefore.Value))
-                .SkipLast(last.Value)
+                .If(createdBefore.HasValue, x => x.Where(y => y.Created < createdBefore!.Value))
+                .If(last.HasValue, x => x.SkipLast(last!.Value))
                 .Any());
 
         public Task<int> GetTotalCountAsync(CancellationToken cancellationToken) => Task.FromResult(Cars.Count);
@@ -148,7 +148,7 @@ namespace ApiTemplate.Repositories
                 throw new ArgumentNullException(nameof(car));
             }
 
-            var existingCar = Cars.FirstOrDefault(x => x.CarId == car.CarId);
+            var existingCar = Cars.First(x => x.CarId == car.CarId);
             existingCar.Cylinders = car.Cylinders;
             existingCar.Make = car.Make;
             existingCar.Model = car.Model;

--- a/Source/ApiTemplate/Source/ApiTemplate/Repositories/ICarRepository.cs
+++ b/Source/ApiTemplate/Source/ApiTemplate/Repositories/ICarRepository.cs
@@ -12,7 +12,7 @@ namespace ApiTemplate.Repositories
 
         Task DeleteAsync(Car car, CancellationToken cancellationToken);
 
-        Task<Car> GetAsync(int carId, CancellationToken cancellationToken);
+        Task<Car?> GetAsync(int carId, CancellationToken cancellationToken);
 
         Task<List<Car>> GetCarsAsync(
             int? first,

--- a/Source/ApiTemplate/Source/ApiTemplate/ViewModels/Car.cs
+++ b/Source/ApiTemplate/Source/ApiTemplate/ViewModels/Car.cs
@@ -31,7 +31,7 @@ namespace ApiTemplate.ViewModels
         /// </summary>
         /// <example>Honda</example>
 #endif
-        public string Make { get; set; }
+        public string Make { get; set; } = default!;
 
 #if Swagger
         /// <summary>
@@ -39,7 +39,7 @@ namespace ApiTemplate.ViewModels
         /// </summary>
         /// <example>Civic</example>
 #endif
-        public string Model { get; set; }
+        public string Model { get; set; } = default!;
 
 #if Swagger
         /// <summary>
@@ -47,6 +47,6 @@ namespace ApiTemplate.ViewModels
         /// </summary>
         /// <example>/cars/1</example>
 #endif
-        public Uri Url { get; set; }
+        public Uri Url { get; set; } = default!;
     }
 }

--- a/Source/ApiTemplate/Source/ApiTemplate/ViewModels/Connection.cs
+++ b/Source/ApiTemplate/Source/ApiTemplate/ViewModels/Connection.cs
@@ -25,7 +25,7 @@ namespace ApiTemplate.ViewModels
         /// Gets or sets the page information.
         /// </summary>
 #endif
-        public PageInfo PageInfo { get; set; }
+        public PageInfo PageInfo { get; set; } = default!;
 
 #if Swagger
         /// <summary>

--- a/Source/ApiTemplate/Source/ApiTemplate/ViewModels/PageInfo.cs
+++ b/Source/ApiTemplate/Source/ApiTemplate/ViewModels/PageInfo.cs
@@ -45,7 +45,7 @@ namespace ApiTemplate.ViewModels
         /// </summary>
         /// <example>/cars?First=10&amp;After=MjAxOS0xMC0yNlQxNDozNDo1MC4xOTgwNzY2KzAwOjAw</example>
 #endif
-        public Uri NextPageUrl { get; set; }
+        public Uri? NextPageUrl { get; set; }
 
 #if Swagger
         /// <summary>
@@ -53,7 +53,7 @@ namespace ApiTemplate.ViewModels
         /// </summary>
         /// <example>/cars?First=10&amp;Before=MjAxOS0xMC0yNlQxNDozNDo1MC4xOTgwNzY2KzAwOjAw</example>
 #endif
-        public Uri PreviousPageUrl { get; set; }
+        public Uri? PreviousPageUrl { get; set; }
 
 #if Swagger
         /// <summary>
@@ -61,7 +61,7 @@ namespace ApiTemplate.ViewModels
         /// </summary>
         /// <example>/cars?First=10</example>
 #endif
-        public Uri FirstPageUrl { get; set; }
+        public Uri FirstPageUrl { get; set; } = default!;
 
 #if Swagger
         /// <summary>
@@ -69,7 +69,7 @@ namespace ApiTemplate.ViewModels
         /// </summary>
         /// <example>/cars?Last=10</example>
 #endif
-        public Uri LastPageUrl { get; set; }
+        public Uri LastPageUrl { get; set; } = default!;
 
         /// <summary>
         /// Gets the Link HTTP header value to add URL's to next, previous, first and last pages.

--- a/Source/ApiTemplate/Source/ApiTemplate/ViewModels/PageOptions.cs
+++ b/Source/ApiTemplate/Source/ApiTemplate/ViewModels/PageOptions.cs
@@ -33,7 +33,7 @@ namespace ApiTemplate.ViewModels
         /// </summary>
         /// <example></example>
 #endif
-        public string After { get; set; }
+        public string? After { get; set; }
 
 #if Swagger
         /// <summary>
@@ -41,6 +41,6 @@ namespace ApiTemplate.ViewModels
         /// </summary>
         /// <example></example>
 #endif
-        public string Before { get; set; }
+        public string? Before { get; set; }
     }
 }

--- a/Source/ApiTemplate/Source/ApiTemplate/ViewModels/SaveCar.cs
+++ b/Source/ApiTemplate/Source/ApiTemplate/ViewModels/SaveCar.cs
@@ -25,7 +25,7 @@ namespace ApiTemplate.ViewModels
         /// <example>Honda</example>
 #endif
         [Required]
-        public string Make { get; set; }
+        public string Make { get; set; } = default!;
 
 #if Swagger
         /// <summary>
@@ -34,6 +34,6 @@ namespace ApiTemplate.ViewModels
         /// <example>Civic</example>
 #endif
         [Required]
-        public string Model { get; set; }
+        public string Model { get; set; } = default!;
     }
 }

--- a/Source/ApiTemplate/Tests/ApiTemplate.IntegrationTest/Controllers/CarsControllerTest.cs
+++ b/Source/ApiTemplate/Tests/ApiTemplate.IntegrationTest/Controllers/CarsControllerTest.cs
@@ -84,7 +84,7 @@ namespace ApiTemplate.IntegrationTest.Controllers
         [Fact]
         public async Task Delete_CarNotFound_Returns404NotFoundAsync()
         {
-            this.CarRepositoryMock.Setup(x => x.GetAsync(999, It.IsAny<CancellationToken>())).ReturnsAsync((Models.Car)null);
+            this.CarRepositoryMock.Setup(x => x.GetAsync(999, It.IsAny<CancellationToken>())).ReturnsAsync((Models.Car?)null);
 
             var response = await this.client.DeleteAsync(new Uri("/cars/999", UriKind.Relative)).ConfigureAwait(false);
 
@@ -103,14 +103,14 @@ namespace ApiTemplate.IntegrationTest.Controllers
 
             Assert.Equal(HttpStatusCode.OK, response.StatusCode);
             Assert.Equal(new DateTimeOffset(2000, 1, 2, 3, 4, 5, TimeSpan.FromHours(6)), response.Content.Headers.LastModified);
-            Assert.Equal(ContentType.RestfulJson, response.Content.Headers.ContentType.MediaType);
+            Assert.Equal(ContentType.RestfulJson, response.Content.Headers.ContentType!.MediaType);
             var carViewModel = await response.Content.ReadAsAsync<Car>(this.formatters).ConfigureAwait(false);
         }
 
         [Fact]
         public async Task Get_CarNotFound_Returns404NotFoundAsync()
         {
-            this.CarRepositoryMock.Setup(x => x.GetAsync(999, It.IsAny<CancellationToken>())).ReturnsAsync((Models.Car)null);
+            this.CarRepositoryMock.Setup(x => x.GetAsync(999, It.IsAny<CancellationToken>())).ReturnsAsync((Models.Car?)null);
 
             var response = await this.client.GetAsync(new Uri("/cars/999", UriKind.Relative)).ConfigureAwait(false);
 
@@ -122,7 +122,7 @@ namespace ApiTemplate.IntegrationTest.Controllers
         [Fact]
         public async Task Get_InvalidAcceptHeader_Returns406NotAcceptableAsync()
         {
-            this.CarRepositoryMock.Setup(x => x.GetAsync(1, It.IsAny<CancellationToken>())).ReturnsAsync((Models.Car)null);
+            this.CarRepositoryMock.Setup(x => x.GetAsync(1, It.IsAny<CancellationToken>())).ReturnsAsync((Models.Car?)null);
             using var request = new HttpRequestMessage(HttpMethod.Get, "/cars/1");
             request.Headers.Accept.Add(new MediaTypeWithQualityHeaderValue(ContentType.Text));
 
@@ -179,7 +179,7 @@ namespace ApiTemplate.IntegrationTest.Controllers
             var response = await this.client.GetAsync(new Uri(path, UriKind.Relative)).ConfigureAwait(false);
 
             Assert.Equal(HttpStatusCode.OK, response.StatusCode);
-            Assert.Equal(ContentType.RestfulJson, response.Content.Headers.ContentType.MediaType);
+            Assert.Equal(ContentType.RestfulJson, response.Content.Headers.ContentType!.MediaType);
             await this.AssertPageUrlsAsync(
                     response,
 #if HttpsEverywhere
@@ -213,7 +213,7 @@ namespace ApiTemplate.IntegrationTest.Controllers
                 .ConfigureAwait(false);
 
             Assert.Equal(HttpStatusCode.OK, response.StatusCode);
-            Assert.Equal(ContentType.RestfulJson, response.Content.Headers.ContentType.MediaType);
+            Assert.Equal(ContentType.RestfulJson, response.Content.Headers.ContentType!.MediaType);
             await this.AssertPageUrlsAsync(
                     response,
                     nextPageUrl: null,
@@ -247,7 +247,7 @@ namespace ApiTemplate.IntegrationTest.Controllers
             var response = await this.client.GetAsync(new Uri(path, UriKind.Relative)).ConfigureAwait(false);
 
             Assert.Equal(HttpStatusCode.OK, response.StatusCode);
-            Assert.Equal(ContentType.RestfulJson, response.Content.Headers.ContentType.MediaType);
+            Assert.Equal(ContentType.RestfulJson, response.Content.Headers.ContentType!.MediaType);
             await this.AssertPageUrlsAsync(
                     response,
                     nextPageUrl: null,
@@ -281,7 +281,7 @@ namespace ApiTemplate.IntegrationTest.Controllers
                 .ConfigureAwait(false);
 
             Assert.Equal(HttpStatusCode.OK, response.StatusCode);
-            Assert.Equal(ContentType.RestfulJson, response.Content.Headers.ContentType.MediaType);
+            Assert.Equal(ContentType.RestfulJson, response.Content.Headers.ContentType!.MediaType);
             await this.AssertPageUrlsAsync(
                     response,
 #if HttpsEverywhere
@@ -315,7 +315,7 @@ namespace ApiTemplate.IntegrationTest.Controllers
                 .ConfigureAwait(false);
 
             Assert.Equal(HttpStatusCode.OK, response.StatusCode);
-            Assert.Equal(ContentType.RestfulJson, response.Content.Headers.ContentType.MediaType);
+            Assert.Equal(ContentType.RestfulJson, response.Content.Headers.ContentType!.MediaType);
             await this.AssertPageUrlsAsync(
                     response,
 #if HttpsEverywhere
@@ -352,7 +352,7 @@ namespace ApiTemplate.IntegrationTest.Controllers
             var response = await this.client.PostAsJsonAsync("cars", saveCar).ConfigureAwait(false);
 
             Assert.Equal(HttpStatusCode.Created, response.StatusCode);
-            Assert.Equal(ContentType.RestfulJson, response.Content.Headers.ContentType.MediaType);
+            Assert.Equal(ContentType.RestfulJson, response.Content.Headers.ContentType!.MediaType);
             var carViewModel = await response.Content.ReadAsAsync<Car>(this.formatters).ConfigureAwait(false);
 #if HttpsEverywhere
             Assert.Equal(new Uri("https://localhost/cars/1"), response.Headers.Location);
@@ -376,7 +376,7 @@ namespace ApiTemplate.IntegrationTest.Controllers
         {
             using var request = new HttpRequestMessage(HttpMethod.Post, "cars")
             {
-                Content = new ObjectContent<SaveCar>(null, new JsonMediaTypeFormatter(), ContentType.Json),
+                Content = new ObjectContent<SaveCar>(null!, new JsonMediaTypeFormatter(), ContentType.Json),
             };
 
             var response = await this.client.SendAsync(request).ConfigureAwait(false);
@@ -420,7 +420,7 @@ namespace ApiTemplate.IntegrationTest.Controllers
             var response = await this.client.PutAsJsonAsync("cars/1", saveCar).ConfigureAwait(false);
 
             Assert.Equal(HttpStatusCode.OK, response.StatusCode);
-            Assert.Equal(ContentType.RestfulJson, response.Content.Headers.ContentType.MediaType);
+            Assert.Equal(ContentType.RestfulJson, response.Content.Headers.ContentType!.MediaType);
             var carViewModel = await response.Content.ReadAsAsync<Car>(this.formatters).ConfigureAwait(false);
         }
 
@@ -433,7 +433,7 @@ namespace ApiTemplate.IntegrationTest.Controllers
                 Make = "Honda",
                 Model = "Civic",
             };
-            this.CarRepositoryMock.Setup(x => x.GetAsync(999, It.IsAny<CancellationToken>())).ReturnsAsync((Models.Car)null);
+            this.CarRepositoryMock.Setup(x => x.GetAsync(999, It.IsAny<CancellationToken>())).ReturnsAsync((Models.Car?)null);
 
             var response = await this.client.PutAsJsonAsync("cars/999", saveCar).ConfigureAwait(false);
 
@@ -459,7 +459,7 @@ namespace ApiTemplate.IntegrationTest.Controllers
             patch.Remove(x => x.Make);
             var json = JsonConvert.SerializeObject(patch);
             using var content = new StringContent(json, Encoding.UTF8, ContentType.JsonPatch);
-            this.CarRepositoryMock.Setup(x => x.GetAsync(999, It.IsAny<CancellationToken>())).ReturnsAsync((Models.Car)null);
+            this.CarRepositoryMock.Setup(x => x.GetAsync(999, It.IsAny<CancellationToken>())).ReturnsAsync((Models.Car?)null);
 
             var response = await this.client
                 .PatchAsync(new Uri("cars/999", UriKind.Relative), content)
@@ -519,8 +519,8 @@ namespace ApiTemplate.IntegrationTest.Controllers
 
         private async Task AssertPageUrlsAsync(
             HttpResponseMessage response,
-            string nextPageUrl,
-            string previousPageUrl,
+            string? nextPageUrl,
+            string? previousPageUrl,
             int expectedPageCount,
             int actualPageCount,
             int totalCount)

--- a/Source/ApiTemplate/Tests/ApiTemplate.IntegrationTest/CustomWebApplicationFactory.cs
+++ b/Source/ApiTemplate/Tests/ApiTemplate.IntegrationTest/CustomWebApplicationFactory.cs
@@ -30,7 +30,7 @@ namespace ApiTemplate.IntegrationTest
                 .CreateLogger();
         }
 
-        public ApplicationOptions ApplicationOptions { get; private set; }
+        public ApplicationOptions ApplicationOptions { get; private set; } = default!;
 
         public Mock<ICarRepository> CarRepositoryMock { get; } = new Mock<ICarRepository>(MockBehavior.Strict);
 


### PR DESCRIPTION
**Add C# 8 Nullable Reference Types in the the ApiTemplate project.**

- Add `<Nullable>` in `Directory.Build.props` - applies `<Nullable>` to: `ApiTemplate` **and**  `ApiTemplate.IntegrationTest`.
- Update properties without changing application behaviour.
- Update unit tests.

Reference issues:
#505 

<!--
Thank you good citizen for your hard work!

Please read the contributing guide before raising a pull request.
https://github.com/Dotnet-Boxed/Templates/blob/main/.github/CONTRIBUTING.md
-->
