### PR TITLE
Fixing docker-vs integration issue

### DIFF
--- a/Source/ApiTemplate/Source/ApiTemplate/ApiTemplate.csproj
+++ b/Source/ApiTemplate/Source/ApiTemplate/ApiTemplate.csproj
@@ -29,7 +29,7 @@
 
   <PropertyGroup Label="Docker" Condition="'$(Docker)' == 'true'">
     <DockerDefaultTargetOS>Linux</DockerDefaultTargetOS>
-    <DockerfileContext>..\..\</DockerfileContext>
+    <DockerfileContext>..\..</DockerfileContext>
   </PropertyGroup>
 
   <PropertyGroup Label="Package">

--- a/Source/GraphQLTemplate/Source/GraphQLTemplate/GraphQLTemplate.csproj
+++ b/Source/GraphQLTemplate/Source/GraphQLTemplate/GraphQLTemplate.csproj
@@ -27,7 +27,7 @@
 
   <PropertyGroup Label="Docker" Condition="'$(Docker)' == 'true'">
     <DockerDefaultTargetOS>Linux</DockerDefaultTargetOS>
-    <DockerfileContext>..\..\</DockerfileContext>
+    <DockerfileContext>..\..</DockerfileContext>
   </PropertyGroup>
 
   <PropertyGroup Label="Package">

--- a/Source/OrleansTemplate/Source/OrleansTemplate.Server/OrleansTemplate.Server.csproj
+++ b/Source/OrleansTemplate/Source/OrleansTemplate.Server/OrleansTemplate.Server.csproj
@@ -25,7 +25,7 @@
 
   <PropertyGroup Label="Docker" Condition="'$(Docker)' == 'true'">
     <DockerDefaultTargetOS>Linux</DockerDefaultTargetOS>
-    <DockerfileContext>..\..\</DockerfileContext>
+    <DockerfileContext>..\..</DockerfileContext>
   </PropertyGroup>
 
   <PropertyGroup Label="Package">


### PR DESCRIPTION
Fix for error occurs in docker Visual Studio 2019 integration:
```
unable to prepare context: path "Z:\\Project\\TrainingPlatform\\TrainingPlatform.API\" " not found
```