### PR TITLE
Up Bump .NET SDK from 5.0.100 to 5.0.102

### DIFF
--- a/Source/ApiTemplate/Tests/ApiTemplate.IntegrationTest/ApiTemplate.IntegrationTest.csproj
+++ b/Source/ApiTemplate/Tests/ApiTemplate.IntegrationTest/ApiTemplate.IntegrationTest.csproj
@@ -13,7 +13,7 @@
   </PropertyGroup>
 
   <ItemGroup Label="Package Versions">
-    <PackageReference Include="coverlet.collector" PrivateAssets="all" Version="1.3.0">
+    <PackageReference Include="coverlet.collector" PrivateAssets="all" Version="3.0.0">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="Microsoft.AspNet.WebApi.Client" Version="5.2.7" />

--- a/Source/ApiTemplate/dotnet-tools.json
+++ b/Source/ApiTemplate/dotnet-tools.json
@@ -3,7 +3,7 @@
   "isRoot": true,
   "tools": {
     "cake.tool": {
-      "version": "1.0.0-rc0001",
+      "version": "1.0.0-rc0002",
       "commands": [
         "dotnet-cake"
       ]

--- a/Source/ApiTemplate/global.json
+++ b/Source/ApiTemplate/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
     "rollForward": "latestMajor",
-    "version": "5.0.101"
+    "version": "5.0.102"
   }
 }

--- a/Source/GraphQLTemplate/Tests/GraphQLTemplate.IntegrationTest/GraphQLTemplate.IntegrationTest.csproj
+++ b/Source/GraphQLTemplate/Tests/GraphQLTemplate.IntegrationTest/GraphQLTemplate.IntegrationTest.csproj
@@ -13,7 +13,7 @@
   </PropertyGroup>
 
   <ItemGroup Label="Package Versions">
-    <PackageReference Include="coverlet.collector" PrivateAssets="all" Version="1.3.0">
+    <PackageReference Include="coverlet.collector" PrivateAssets="all" Version="3.0.0">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="Microsoft.AspNet.WebApi.Client" Version="5.2.7" />

--- a/Source/GraphQLTemplate/dotnet-tools.json
+++ b/Source/GraphQLTemplate/dotnet-tools.json
@@ -3,7 +3,7 @@
   "isRoot": true,
   "tools": {
     "cake.tool": {
-      "version": "1.0.0-rc0001",
+      "version": "1.0.0-rc0002",
       "commands": [
         "dotnet-cake"
       ]

--- a/Source/GraphQLTemplate/global.json
+++ b/Source/GraphQLTemplate/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
     "rollForward": "latestMajor",
-    "version": "5.0.101"
+    "version": "5.0.102"
   }
 }

--- a/Source/NuGetTemplate/Tests/Directory.Build.props
+++ b/Source/NuGetTemplate/Tests/Directory.Build.props
@@ -3,7 +3,7 @@
   <Import Project="$([MSBuild]::GetPathOfFileAbove('Directory.Build.props', '$(MSBuildThisFileDirectory)../'))" />
 
   <ItemGroup Label="Package References">
-    <PackageReference Include="coverlet.collector" PrivateAssets="all" Version="1.3.0">
+    <PackageReference Include="coverlet.collector" PrivateAssets="all" Version="3.0.0">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.8.3" />

--- a/Source/NuGetTemplate/dotnet-tools.json
+++ b/Source/NuGetTemplate/dotnet-tools.json
@@ -3,7 +3,7 @@
   "isRoot": true,
   "tools": {
     "cake.tool": {
-      "version": "1.0.0-rc0001",
+      "version": "1.0.0-rc0002",
       "commands": [
         "dotnet-cake"
       ]

--- a/Source/NuGetTemplate/global.json
+++ b/Source/NuGetTemplate/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
     "rollForward": "latestMajor",
-    "version": "5.0.101"
+    "version": "5.0.102"
   }
 }

--- a/Source/OrleansTemplate/Tests/OrleansTemplate.Server.IntegrationTest/OrleansTemplate.Server.IntegrationTest.csproj
+++ b/Source/OrleansTemplate/Tests/OrleansTemplate.Server.IntegrationTest/OrleansTemplate.Server.IntegrationTest.csproj
@@ -5,7 +5,7 @@
   </PropertyGroup>
 
   <ItemGroup Label="Package Versions">
-    <PackageReference Include="coverlet.collector" PrivateAssets="all" Version="1.3.0">
+    <PackageReference Include="coverlet.collector" PrivateAssets="all" Version="3.0.0">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.8.3" />

--- a/Source/OrleansTemplate/dotnet-tools.json
+++ b/Source/OrleansTemplate/dotnet-tools.json
@@ -3,7 +3,7 @@
   "isRoot": true,
   "tools": {
     "cake.tool": {
-      "version": "1.0.0-rc0001",
+      "version": "1.0.0-rc0002",
       "commands": [
         "dotnet-cake"
       ]

--- a/Source/OrleansTemplate/global.json
+++ b/Source/OrleansTemplate/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
     "rollForward": "latestMajor",
-    "version": "5.0.101"
+    "version": "5.0.102"
   }
 }

--- a/Tests/Boxed.Templates.FunctionalTest/Boxed.Templates.FunctionalTest.csproj
+++ b/Tests/Boxed.Templates.FunctionalTest/Boxed.Templates.FunctionalTest.csproj
@@ -10,7 +10,7 @@
 
   <ItemGroup Label="Package References">
     <PackageReference Include="Boxed.DotnetNewTest" Version="3.7.1" />
-    <PackageReference Include="coverlet.collector" PrivateAssets="all" Version="1.3.0">
+    <PackageReference Include="coverlet.collector" PrivateAssets="all" Version="3.0.0">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="Microsoft.AspNet.WebApi.Client" Version="5.2.7" />

--- a/dotnet-tools.json
+++ b/dotnet-tools.json
@@ -3,7 +3,7 @@
   "isRoot": true,
   "tools": {
     "cake.tool": {
-      "version": "1.0.0-rc0001",
+      "version": "1.0.0-rc0002",
       "commands": [
         "dotnet-cake"
       ]

--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
     "rollForward": "latestMajor",
-    "version": "5.0.101"
+    "version": "5.0.102"
   }
 }


### PR DESCRIPTION
- Bump .NET SDK from 5.0.100 to 5.0.102.
- Bump cake.tool to RC2.