### PR TITLE
Bump StyleCop and Open Telemetry Improvements

### DIFF
--- a/Source/ApiTemplate/Directory.Build.props
+++ b/Source/ApiTemplate/Directory.Build.props
@@ -23,7 +23,7 @@
   <ItemGroup Label="Package References">
     <PackageReference Include="Microsoft.VisualStudio.Threading.Analyzers" PrivateAssets="all" Version="16.8.55" />
     <PackageReference Include="MinVer" PrivateAssets="all" Version="2.4.0" />
-    <PackageReference Include="StyleCop.Analyzers" PrivateAssets="all" Version="1.1.118" Condition="'$(StyleCop)' == 'true'" />
+    <PackageReference Include="StyleCop.Analyzers" PrivateAssets="all" Version="1.2.0-beta.321" Condition="'$(StyleCop)' == 'true'" />
   </ItemGroup>
 
 </Project>

--- a/Source/ApiTemplate/Source/ApiTemplate/ApplicationBuilderExtensions.cs
+++ b/Source/ApiTemplate/Source/ApiTemplate/ApplicationBuilderExtensions.cs
@@ -2,9 +2,6 @@ namespace ApiTemplate
 {
     using System;
     using System.Linq;
-#if Versioning
-    using System.Reflection;
-#endif
     using ApiTemplate.Constants;
     using ApiTemplate.Options;
     using Boxed.AspNetCore;
@@ -113,10 +110,7 @@ namespace ApiTemplate
                 options =>
                 {
                     // Set the Swagger UI browser document title.
-                    options.DocumentTitle = typeof(Startup)
-                        .Assembly
-                        .GetCustomAttribute<AssemblyProductAttribute>()
-                        .Product;
+                    options.DocumentTitle = AssemblyInformation.Current.Product;
                     // Set the Swagger UI to render at '/'.
                     options.RoutePrefix = string.Empty;
 

--- a/Source/ApiTemplate/Source/ApiTemplate/AssemblyInformation.cs
+++ b/Source/ApiTemplate/Source/ApiTemplate/AssemblyInformation.cs
@@ -1,0 +1,17 @@
+namespace ApiTemplate
+{
+    using System.Reflection;
+
+    public record AssemblyInformation(string Product, string Description, string Version)
+    {
+        public static readonly AssemblyInformation Current = new AssemblyInformation(typeof(AssemblyInformation).Assembly);
+
+        public AssemblyInformation(Assembly assembly)
+            : this(
+                assembly.GetCustomAttribute<AssemblyProductAttribute>().Product,
+                assembly.GetCustomAttribute<AssemblyDescriptionAttribute>().Description,
+                assembly.GetCustomAttribute<AssemblyFileVersionAttribute>().Version)
+        {
+        }
+    }
+}

--- a/Source/ApiTemplate/Source/ApiTemplate/CustomServiceCollectionExtensions.cs
+++ b/Source/ApiTemplate/Source/ApiTemplate/CustomServiceCollectionExtensions.cs
@@ -6,9 +6,6 @@ namespace ApiTemplate
     using System.IO.Compression;
 #endif
     using System.Linq;
-#if Swagger
-    using System.Reflection;
-#endif
 #if CORS
     using ApiTemplate.Constants;
 #endif
@@ -226,12 +223,12 @@ namespace ApiTemplate
                             .CreateDefault()
                             .AddService(
                                 webHostEnvironment.ApplicationName,
-                                serviceVersion: typeof(Startup).Assembly.GetCustomAttribute<AssemblyFileVersionAttribute>().Version)
+                                serviceVersion: AssemblyInformation.Current.Version)
                             .AddAttributes(
                                 new KeyValuePair<string, object>[]
                                 {
-                                    new (OpenTelemetryAttributeName.Deployment.Environment, webHostEnvironment.EnvironmentName),
-                                    new (OpenTelemetryAttributeName.Host.Name, Environment.MachineName),
+                                    new(OpenTelemetryAttributeName.Deployment.Environment, webHostEnvironment.EnvironmentName),
+                                    new(OpenTelemetryAttributeName.Host.Name, Environment.MachineName),
                                 }))
                         .AddAspNetCoreInstrumentation(
                             options =>
@@ -314,15 +311,11 @@ namespace ApiTemplate
             services.AddSwaggerGen(
                 options =>
                 {
-                    var assembly = typeof(Startup).Assembly;
-                    var assemblyProduct = assembly.GetCustomAttribute<AssemblyProductAttribute>().Product;
-                    var assemblyDescription = assembly.GetCustomAttribute<AssemblyDescriptionAttribute>().Description;
-
                     options.DescribeAllParametersInCamelCase();
                     options.EnableAnnotations();
 
                     // Add the XML comment file for this assembly, so its contents can be displayed.
-                    options.IncludeXmlCommentsIfExists(assembly);
+                    options.IncludeXmlCommentsIfExists(typeof(Startup).Assembly);
 
 #if Versioning
                     options.OperationFilter<ApiVersionOperationFilter>();
@@ -340,10 +333,10 @@ namespace ApiTemplate
                     {
                         var info = new OpenApiInfo()
                         {
-                            Title = assemblyProduct,
+                            Title = AssemblyInformation.Current.Product,
                             Description = apiVersionDescription.IsDeprecated ?
-                                $"{assemblyDescription} This API version has been deprecated." :
-                                assemblyDescription,
+                                $"{AssemblyInformation.Current.Description} This API version has been deprecated." :
+                                AssemblyInformation.Current.Description,
                             Version = apiVersionDescription.ApiVersion.ToString(),
                         };
                         options.SwaggerDoc(apiVersionDescription.GroupName, info);
@@ -351,8 +344,8 @@ namespace ApiTemplate
 #else
                     var info = new Info()
                     {
-                        Title = assemblyProduct,
-                        Description = assemblyDescription,
+                        Title = AssemblyInformation.Current.Product,
+                        Description = AssemblyInformation.Current.Description,
                         Version = "v1"
                     };
                     options.SwaggerDoc("v1", info);

--- a/Source/ApiTemplate/Source/ApiTemplate/Program.cs
+++ b/Source/ApiTemplate/Source/ApiTemplate/Program.cs
@@ -28,7 +28,7 @@ namespace ApiTemplate
             }
 
             var hostEnvironment = host.Services.GetRequiredService<IHostEnvironment>();
-            hostEnvironment.ApplicationName = Assembly.GetExecutingAssembly().GetCustomAttribute<AssemblyProductAttribute>().Product;
+            hostEnvironment.ApplicationName = AssemblyInformation.Current.Product;
 
             Log.Logger = CreateLogger(host);
 

--- a/Source/GraphQLTemplate/Directory.Build.props
+++ b/Source/GraphQLTemplate/Directory.Build.props
@@ -23,7 +23,7 @@
   <ItemGroup Label="Package References">
     <PackageReference Include="Microsoft.VisualStudio.Threading.Analyzers" PrivateAssets="all" Version="16.8.55" />
     <PackageReference Include="MinVer" PrivateAssets="all" Version="2.4.0" />
-    <PackageReference Include="StyleCop.Analyzers" PrivateAssets="all" Version="1.1.118" Condition="'$(StyleCop)' == 'true'" />
+    <PackageReference Include="StyleCop.Analyzers" PrivateAssets="all" Version="1.2.0-beta.321" Condition="'$(StyleCop)' == 'true'" />
   </ItemGroup>
 
 </Project>

--- a/Source/GraphQLTemplate/Source/GraphQLTemplate/CustomServiceCollectionExtensions.cs
+++ b/Source/GraphQLTemplate/Source/GraphQLTemplate/CustomServiceCollectionExtensions.cs
@@ -210,8 +210,8 @@ namespace GraphQLTemplate
                             .AddAttributes(
                                 new KeyValuePair<string, object>[]
                                 {
-                                    new (OpenTelemetryAttributeName.Deployment.Environment, webHostEnvironment.EnvironmentName),
-                                    new (OpenTelemetryAttributeName.Host.Name, Environment.MachineName),
+                                    new(OpenTelemetryAttributeName.Deployment.Environment, webHostEnvironment.EnvironmentName),
+                                    new(OpenTelemetryAttributeName.Host.Name, Environment.MachineName),
                                 }))
                         .AddAspNetCoreInstrumentation(
                             options =>

--- a/Source/NuGetTemplate/Directory.Build.props
+++ b/Source/NuGetTemplate/Directory.Build.props
@@ -34,7 +34,7 @@
     <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" PrivateAssets="all" Version="1.0.0" Condition="'$(DotnetFramework)' == 'true'" />
     <PackageReference Include="Microsoft.VisualStudio.Threading.Analyzers" PrivateAssets="all" Version="16.8.55" />
     <PackageReference Include="MinVer" PrivateAssets="all" Version="2.4.0" />
-    <PackageReference Include="StyleCop.Analyzers" PrivateAssets="all" Version="1.1.118" Condition="'$(StyleCop)' == 'true'" />
+    <PackageReference Include="StyleCop.Analyzers" PrivateAssets="all" Version="1.2.0-beta.321" Condition="'$(StyleCop)' == 'true'" />
   </ItemGroup>
 
 </Project>

--- a/Source/OrleansTemplate/Directory.Build.props
+++ b/Source/OrleansTemplate/Directory.Build.props
@@ -23,7 +23,7 @@
   <ItemGroup Label="Package References">
     <PackageReference Include="Microsoft.VisualStudio.Threading.Analyzers" PrivateAssets="all" Version="16.8.55" />
     <PackageReference Include="MinVer" PrivateAssets="all" Version="2.4.0" />
-    <PackageReference Include="StyleCop.Analyzers" PrivateAssets="all" Version="1.1.118" Condition="'$(StyleCop)' == 'true'" />
+    <PackageReference Include="StyleCop.Analyzers" PrivateAssets="all" Version="1.2.0-beta.321" Condition="'$(StyleCop)' == 'true'" />
   </ItemGroup>
 
 </Project>

--- a/Source/OrleansTemplate/Source/OrleansTemplate.Server/ServiceCollectionExtensions.cs
+++ b/Source/OrleansTemplate/Source/OrleansTemplate.Server/ServiceCollectionExtensions.cs
@@ -37,8 +37,8 @@ namespace OrleansTemplate.Server
                             .AddAttributes(
                                 new KeyValuePair<string, object>[]
                                 {
-                                    new (OpenTelemetryAttributeName.Deployment.Environment, webHostEnvironment.EnvironmentName),
-                                    new (OpenTelemetryAttributeName.Host.Name, Environment.MachineName),
+                                    new(OpenTelemetryAttributeName.Deployment.Environment, webHostEnvironment.EnvironmentName),
+                                    new(OpenTelemetryAttributeName.Host.Name, Environment.MachineName),
                                 }))
                         .AddAspNetCoreInstrumentation(
                             options =>


### PR DESCRIPTION
- Bump StyleCop.Analyzers from 1.1.118 to 1.2.0-beta.321.
- Fix warning in Open Telemetry feature.
- Add AssemblyInformation record to make it easier to get assembly information for API template only.