### PR TITLE
Bump OpenTelemetry.* from 1.0.0-rc2 to 1.0.0-rc3

### DIFF
--- a/Source/ApiTemplate/.template.config/template.json
+++ b/Source/ApiTemplate/.template.config/template.json
@@ -138,7 +138,8 @@
         {
           "condition": "(!OpenTelemetry)",
           "exclude": [
-            "Source/ApiTemplate/Constants/OpenTelemetryAttributeName.cs"
+            "Source/ApiTemplate/Constants/OpenTelemetryAttributeName.cs",
+            "Source/ApiTemplate/Constants/OpenTelemetryHttpFlavour.cs"
           ]
         }
       ]

--- a/Source/ApiTemplate/Source/ApiTemplate/ApiTemplate.csproj
+++ b/Source/ApiTemplate/Source/ApiTemplate/ApiTemplate.csproj
@@ -57,8 +57,8 @@
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Versioning.ApiExplorer" Version="5.0.0" Condition="'$(Versioning)' == 'true'" />
     <PackageReference Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.10.8" Condition="'$(Docker)' == 'true'" />
     <PackageReference Include="OpenTelemetry.Exporter.Console" Version="1.0.1" Condition="'$(OpenTelemetry)' == 'true'" />
-    <PackageReference Include="OpenTelemetry.Extensions.Hosting" Version="1.0.0-rc2" Condition="'$(OpenTelemetry)' == 'true'" />
-    <PackageReference Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.0.0-rc2" Condition="'$(OpenTelemetry)' == 'true'" />
+    <PackageReference Include="OpenTelemetry.Extensions.Hosting" Version="1.0.0-rc3" Condition="'$(OpenTelemetry)' == 'true'" />
+    <PackageReference Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.0.0-rc3" Condition="'$(OpenTelemetry)' == 'true'" />
     <PackageReference Include="Serilog" Version="2.10.0" />
     <PackageReference Include="Serilog.AspNetCore" Version="4.0.0" />
     <PackageReference Include="Serilog.Enrichers.Environment" Version="2.1.3" />

--- a/Source/ApiTemplate/Source/ApiTemplate/Constants/OpenTelemetryHttpFlavour.cs
+++ b/Source/ApiTemplate/Source/ApiTemplate/Constants/OpenTelemetryHttpFlavour.cs
@@ -1,0 +1,10 @@
+namespace ApiTemplate.Constants
+{
+    public static class OpenTelemetryHttpFlavour
+    {
+        public const string Http10 = "1.0";
+        public const string Http11 = "1.1";
+        public const string Http20 = "2.0";
+        public const string Http30 = "3.0";
+    }
+}

--- a/Source/ApiTemplate/Source/ApiTemplate/CustomServiceCollectionExtensions.cs
+++ b/Source/ApiTemplate/Source/ApiTemplate/CustomServiceCollectionExtensions.cs
@@ -226,11 +226,6 @@ namespace ApiTemplate
                                 // See https://github.com/open-telemetry/opentelemetry-specification/blob/master/specification/trace/semantic_conventions/http.md
                                 options.Enrich = (activity, eventName, obj) =>
                                 {
-                                    if (!activity.IsAllDataRequested)
-                                    {
-                                        return;
-                                    }
-
                                     if (obj is HttpRequest request)
                                     {
                                         var context = request.HttpContext;
@@ -257,19 +252,19 @@ namespace ApiTemplate
                                     {
                                         if (HttpProtocol.IsHttp10(protocol))
                                         {
-                                            return "1.0";
+                                            return OpenTelemetryHttpFlavour.Http10;
                                         }
                                         else if (HttpProtocol.IsHttp11(protocol))
                                         {
-                                            return "1.1";
+                                            return OpenTelemetryHttpFlavour.Http11;
                                         }
                                         else if (HttpProtocol.IsHttp2(protocol))
                                         {
-                                            return "2.0";
+                                            return OpenTelemetryHttpFlavour.Http20;
                                         }
                                         else if (HttpProtocol.IsHttp3(protocol))
                                         {
-                                            return "3.0";
+                                            return OpenTelemetryHttpFlavour.Http30;
                                         }
 
                                         throw new InvalidOperationException($"Protocol {protocol} not recognised.");

--- a/Source/GraphQLTemplate/.template.config/template.json
+++ b/Source/GraphQLTemplate/.template.config/template.json
@@ -142,7 +142,8 @@
         {
           "condition": "(!OpenTelemetry)",
           "exclude": [
-            "Source/GraphQLTemplate/Constants/OpenTelemetryAttributeName.cs"
+            "Source/GraphQLTemplate/Constants/OpenTelemetryAttributeName.cs",
+            "Source/GraphQLTemplate/Constants/OpenTelemetryHttpFlavour.cs"
           ]
         }
       ]

--- a/Source/GraphQLTemplate/Source/GraphQLTemplate/Constants/OpenTelemetryHttpFlavour.cs
+++ b/Source/GraphQLTemplate/Source/GraphQLTemplate/Constants/OpenTelemetryHttpFlavour.cs
@@ -1,0 +1,10 @@
+namespace GraphQLTemplate.Constants
+{
+    public static class OpenTelemetryHttpFlavour
+    {
+        public const string Http10 = "1.0";
+        public const string Http11 = "1.1";
+        public const string Http20 = "2.0";
+        public const string Http30 = "3.0";
+    }
+}

--- a/Source/GraphQLTemplate/Source/GraphQLTemplate/CustomServiceCollectionExtensions.cs
+++ b/Source/GraphQLTemplate/Source/GraphQLTemplate/CustomServiceCollectionExtensions.cs
@@ -220,11 +220,6 @@ namespace GraphQLTemplate
                                 // See https://github.com/open-telemetry/opentelemetry-specification/blob/master/specification/trace/semantic_conventions/http.md
                                 options.Enrich = (activity, eventName, obj) =>
                                 {
-                                    if (!activity.IsAllDataRequested)
-                                    {
-                                        return;
-                                    }
-
                                     if (obj is HttpRequest request)
                                     {
                                         var context = request.HttpContext;
@@ -251,19 +246,19 @@ namespace GraphQLTemplate
                                     {
                                         if (HttpProtocol.IsHttp10(protocol))
                                         {
-                                            return "1.0";
+                                            return OpenTelemetryHttpFlavour.Http10;
                                         }
                                         else if (HttpProtocol.IsHttp11(protocol))
                                         {
-                                            return "1.1";
+                                            return OpenTelemetryHttpFlavour.Http11;
                                         }
                                         else if (HttpProtocol.IsHttp2(protocol))
                                         {
-                                            return "2.0";
+                                            return OpenTelemetryHttpFlavour.Http20;
                                         }
                                         else if (HttpProtocol.IsHttp3(protocol))
                                         {
-                                            return "3.0";
+                                            return OpenTelemetryHttpFlavour.Http30;
                                         }
 
                                         throw new InvalidOperationException($"Protocol {protocol} not recognised.");

--- a/Source/GraphQLTemplate/Source/GraphQLTemplate/GraphQLTemplate.csproj
+++ b/Source/GraphQLTemplate/Source/GraphQLTemplate/GraphQLTemplate.csproj
@@ -59,8 +59,8 @@
     <PackageReference Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.10.8" Condition="'$(Docker)' == 'true'" />
     <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
     <PackageReference Include="OpenTelemetry.Exporter.Console" Version="1.0.1" Condition="'$(OpenTelemetry)' == 'true'" />
-    <PackageReference Include="OpenTelemetry.Extensions.Hosting" Version="1.0.0-rc2" Condition="'$(OpenTelemetry)' == 'true'" />
-    <PackageReference Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.0.0-rc2" Condition="'$(OpenTelemetry)' == 'true'" />
+    <PackageReference Include="OpenTelemetry.Extensions.Hosting" Version="1.0.0-rc3" Condition="'$(OpenTelemetry)' == 'true'" />
+    <PackageReference Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.0.0-rc3" Condition="'$(OpenTelemetry)' == 'true'" />
     <PackageReference Include="Serilog" Version="2.10.0" />
     <PackageReference Include="Serilog.AspNetCore" Version="4.0.0" />
     <PackageReference Include="Serilog.Enrichers.Environment" Version="2.1.3" />

--- a/Source/OrleansTemplate/.template.config/template.json
+++ b/Source/OrleansTemplate/.template.config/template.json
@@ -86,6 +86,7 @@
           "condition": "(!OpenTelemetry)",
           "exclude": [
             "Source/OrleansTemplate.Abstractions/Constants/OpenTelemetryAttributeName.cs",
+            "Source/OrleansTemplate.Abstractions/Constants/OpenTelemetryHttpFlavour.cs",
             "Source/OrleansTemplate.Server/ServiceCollectionExtensions.cs"
           ]
         }

--- a/Source/OrleansTemplate/Source/OrleansTemplate.Abstractions/Constants/OpenTelemetryHttpFlavour.cs
+++ b/Source/OrleansTemplate/Source/OrleansTemplate.Abstractions/Constants/OpenTelemetryHttpFlavour.cs
@@ -1,0 +1,10 @@
+namespace OrleansTemplate.Abstractions.Constants
+{
+    public static class OpenTelemetryHttpFlavour
+    {
+        public const string Http10 = "1.0";
+        public const string Http11 = "1.1";
+        public const string Http20 = "2.0";
+        public const string Http30 = "3.0";
+    }
+}

--- a/Source/OrleansTemplate/Source/OrleansTemplate.Server/OrleansTemplate.Server.csproj
+++ b/Source/OrleansTemplate/Source/OrleansTemplate.Server/OrleansTemplate.Server.csproj
@@ -56,8 +56,8 @@
     <PackageReference Include="Microsoft.Orleans.Transactions.AzureStorage" Version="3.4.1" />
     <PackageReference Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.10.8" Condition="'$(Docker)' == 'true'" />
     <PackageReference Include="OpenTelemetry.Exporter.Console" Version="1.0.1" Condition="'$(OpenTelemetry)' == 'true'" />
-    <PackageReference Include="OpenTelemetry.Extensions.Hosting" Version="1.0.0-rc2" Condition="'$(OpenTelemetry)' == 'true'" />
-    <PackageReference Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.0.0-rc2" Condition="'$(OpenTelemetry)' == 'true'" />
+    <PackageReference Include="OpenTelemetry.Extensions.Hosting" Version="1.0.0-rc3" Condition="'$(OpenTelemetry)' == 'true'" />
+    <PackageReference Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.0.0-rc3" Condition="'$(OpenTelemetry)' == 'true'" />
     <PackageReference Include="Serilog" Version="2.10.0" />
     <PackageReference Include="Serilog.AspNetCore" Version="4.0.0" />
     <PackageReference Include="Serilog.Enrichers.Environment" Version="2.1.3" />

--- a/Source/OrleansTemplate/Source/OrleansTemplate.Server/ServiceCollectionExtensions.cs
+++ b/Source/OrleansTemplate/Source/OrleansTemplate.Server/ServiceCollectionExtensions.cs
@@ -47,11 +47,6 @@ namespace OrleansTemplate.Server
                                 // See https://github.com/open-telemetry/opentelemetry-specification/blob/master/specification/trace/semantic_conventions/http.md
                                 options.Enrich = (activity, eventName, obj) =>
                                 {
-                                    if (!activity.IsAllDataRequested)
-                                    {
-                                        return;
-                                    }
-
                                     if (obj is HttpRequest request)
                                     {
                                         var context = request.HttpContext;
@@ -78,19 +73,19 @@ namespace OrleansTemplate.Server
                                     {
                                         if (HttpProtocol.IsHttp10(protocol))
                                         {
-                                            return "1.0";
+                                            return OpenTelemetryHttpFlavour.Http10;
                                         }
                                         else if (HttpProtocol.IsHttp11(protocol))
                                         {
-                                            return "1.1";
+                                            return OpenTelemetryHttpFlavour.Http11;
                                         }
                                         else if (HttpProtocol.IsHttp2(protocol))
                                         {
-                                            return "2.0";
+                                            return OpenTelemetryHttpFlavour.Http20;
                                         }
                                         else if (HttpProtocol.IsHttp3(protocol))
                                         {
-                                            return "3.0";
+                                            return OpenTelemetryHttpFlavour.Http30;
                                         }
 
                                         throw new InvalidOperationException($"Protocol {protocol} not recognised.");


### PR DESCRIPTION
- Bump `OpenTelemetry.*` from `1.0.0-rc2` to `1.0.0-rc3`.
- `IsAllDataRequested` is now checked for us, so we no longer need to check it.
- Added `OpenTelemetryHttpFlavour` constants.