### PR TITLE
Upgrade Hot Chocolate from v11 to v11.1

### DIFF
--- a/Source/GraphQLTemplate/Source/GraphQLTemplate/CustomServiceCollectionExtensions.cs
+++ b/Source/GraphQLTemplate/Source/GraphQLTemplate/CustomServiceCollectionExtensions.cs
@@ -325,7 +325,7 @@ namespace GraphQLTemplate
                 .AddIfElse(
                     webHostEnvironment.IsEnvironment(Constants.EnvironmentName.Test),
                     x => x.AddInMemoryQueryStorage(),
-                    // TODO Hot Chocolate v11.1 will not require a call to .GetApplicationServices() below.
+                    // Hot Chocolate contains a bug which requires us to add .GetApplicationServices() below.
                     x => x.AddRedisQueryStorage(x => x.GetApplicationServices().GetRequiredService<IConnectionMultiplexer>().GetDatabase()))
 #endif
 #if Subscriptions

--- a/Source/GraphQLTemplate/Source/GraphQLTemplate/GraphQLTemplate.csproj
+++ b/Source/GraphQLTemplate/Source/GraphQLTemplate/GraphQLTemplate.csproj
@@ -51,20 +51,17 @@
     <PackageReference Include="Boxed.Mapping" Version="5.3.0" />
     <PackageReference Include="GraphQL.Server.Ui.Playground" Version="5.0.1" />
     <PackageReference Include="GraphQL.Server.Ui.Voyager" Version="5.0.1" />
-    <PackageReference Include="HotChocolate.AspNetCore" Version="11.0.9" />
-    <PackageReference Include="HotChocolate.AspNetCore.Authorization" Version="11.0.9" Condition="'$(Authorization)' == 'true'" />
-    <PackageReference Include="HotChocolate.Data" Version="11.0.9" />
-    <PackageReference Include="HotChocolate.Data.Spatial" Version="11.0.9" />
-    <PackageReference Include="HotChocolate.PersistedQueries.InMemory" Version="11.0.9" Condition="'$(PersistedQueries)' == 'true'" />
-    <PackageReference Include="HotChocolate.PersistedQueries.Redis" Version="11.0.9" Condition="'$(PersistedQueries)' == 'true'" />
-    <PackageReference Include="HotChocolate.Subscriptions.Redis" Version="11.0.9" Condition="'$(Subscriptions)' == 'true'" />
-    <PackageReference Include="HotChocolate.Types.Spatial" Version="11.0.9" />
+    <PackageReference Include="HotChocolate.AspNetCore" Version="11.1.0" />
+    <PackageReference Include="HotChocolate.AspNetCore.Authorization" Version="11.1.0" Condition="'$(Authorization)' == 'true'" />
+    <PackageReference Include="HotChocolate.Data" Version="11.1.0" />
+    <PackageReference Include="HotChocolate.PersistedQueries.InMemory" Version="11.1.0" Condition="'$(PersistedQueries)' == 'true'" />
+    <PackageReference Include="HotChocolate.PersistedQueries.Redis" Version="11.1.0" Condition="'$(PersistedQueries)' == 'true'" />
+    <PackageReference Include="HotChocolate.Subscriptions.Redis" Version="11.1.0" Condition="'$(Subscriptions)' == 'true'" />
     <PackageReference Include="Microsoft.ApplicationInsights.AspNetCore" Version="2.17.0" Condition="'$(ApplicationInsights)' == 'true'" />
     <PackageReference Include="Microsoft.AspNetCore.ApplicationInsights.HostingStartup" Version="2.2.0" Condition="'$(ApplicationInsights)' == 'true'" />
     <PackageReference Include="Microsoft.AspNetCore.AzureAppServicesIntegration" Version="5.0.4" Condition="'$(Azure)' == 'true'" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="5.0.4" />
     <PackageReference Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.10.8" Condition="'$(Docker)' == 'true'" />
-    <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
     <PackageReference Include="OpenTelemetry.Exporter.Console" Version="1.0.1" Condition="'$(OpenTelemetry)' == 'true'" />
     <PackageReference Include="OpenTelemetry.Extensions.Hosting" Version="1.0.0-rc3" Condition="'$(OpenTelemetry)' == 'true'" />
     <PackageReference Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.0.0-rc3" Condition="'$(OpenTelemetry)' == 'true'" />

--- a/Source/GraphQLTemplate/Source/GraphQLTemplate/Program.cs
+++ b/Source/GraphQLTemplate/Source/GraphQLTemplate/Program.cs
@@ -95,7 +95,6 @@ namespace GraphQLTemplate
                     (builderContext, options) =>
                     {
                         options.AddServerHeader = false;
-                        options.AllowSynchronousIO = true;
                         options.Configure(builderContext.Configuration.GetSection(nameof(ApplicationOptions.Kestrel)), reloadOnChange: false);
                     })
 #if Azure

--- a/Source/GraphQLTemplate/Source/GraphQLTemplate/Startup.cs
+++ b/Source/GraphQLTemplate/Source/GraphQLTemplate/Startup.cs
@@ -145,6 +145,5 @@ namespace GraphQLTemplate
                         .UseGraphQLPlayground("/")
                         // Add the GraphQL Voyager UI to let you navigate your GraphQL API as a spider graph at /voyager.
                         .UseGraphQLVoyager("/voyager"));
-
     }
 }


### PR DESCRIPTION
- Bump `HotChocolate.*` NuGet packages from `11.0.9` to `11.1.0`.
- Remove unnecessary `Newtonsoft.Json` NuGet package.
- Remove unnecessary Hot Chocolate spatial NuGet packages.
- Remove `AllowSynchronousIO` for better performance.
- Remove blank line.