### PR TITLE
Enforce LF line endings for NPM files in Gitattributes template

### DIFF
--- a/Source/GitattributesTemplate/.gitattributes
+++ b/Source/GitattributesTemplate/.gitattributes
@@ -41,3 +41,14 @@
 
 # Other
 *.exe filter=lfs diff=lfs merge=lfs -text
+
+###############################################################################
+# Behaviour for NPM package files
+#
+# Because NPM writes back a package.json (and the lockfile) you get file
+# changes after each NPM operation on CRLF systems.
+# Set Git to checkout these files with LF line-endings
+###############################################################################
+package.json        text    eol=lf
+package-lock.json   text    eol=lf
+yarn.lock           text    eol=lf


### PR DESCRIPTION
Adds end-of-line rules for NPM/Yarn files used for JavaScript package managers. Each time an `npm` command is executed, NPM will write back the `.json` file and will use LF-line endings. This causes Git to view the file as changed, even if the actual JSON content was not modified on CRLF-systems.

Since JavaScript is used together with C# in some SPA application, it will be useful to add these rules to the gitattributes template.