### PR TITLE
Update JSON Serializer Options

### DIFF
--- a/Source/ApiTemplate/Source/ApiTemplate/Constants/EnvironmentName.cs
+++ b/Source/ApiTemplate/Source/ApiTemplate/Constants/EnvironmentName.cs
@@ -1,0 +1,7 @@
+namespace ApiTemplate.Constants
+{
+    public static class EnvironmentName
+    {
+        public const string Test = nameof(Test);
+    }
+}

--- a/Source/ApiTemplate/Source/ApiTemplate/MvcBuilderExtensions.cs
+++ b/Source/ApiTemplate/Source/ApiTemplate/MvcBuilderExtensions.cs
@@ -23,7 +23,8 @@ namespace ApiTemplate
                 options =>
                 {
                     var jsonSerializerOptions = options.JsonSerializerOptions;
-                    if (webHostEnvironment.IsDevelopment())
+                    if (webHostEnvironment.IsDevelopment() ||
+                        webHostEnvironment.IsEnvironment(Constants.EnvironmentName.Test))
                     {
                         // Pretty print the JSON in development for easier debugging.
                         jsonSerializerOptions.WriteIndented = true;

--- a/Source/ApiTemplate/Tests/ApiTemplate.IntegrationTest/CustomWebApplicationFactory.cs
+++ b/Source/ApiTemplate/Tests/ApiTemplate.IntegrationTest/CustomWebApplicationFactory.cs
@@ -55,7 +55,7 @@ namespace ApiTemplate.IntegrationTest
 
         protected override void ConfigureWebHost(IWebHostBuilder builder) =>
             builder
-                .UseEnvironment("Test")
+                .UseEnvironment(Constants.EnvironmentName.Test)
                 .ConfigureServices(this.ConfigureServices);
 
         protected virtual void ConfigureServices(IServiceCollection services) =>

--- a/Source/GraphQLTemplate/Source/GraphQLTemplate/GraphQLTemplate.csproj
+++ b/Source/GraphQLTemplate/Source/GraphQLTemplate/GraphQLTemplate.csproj
@@ -64,7 +64,6 @@
     <PackageReference Include="Microsoft.ApplicationInsights.AspNetCore" Version="2.18.0" Condition="'$(ApplicationInsights)' == 'true'" />
     <PackageReference Include="Microsoft.AspNetCore.ApplicationInsights.HostingStartup" Version="2.2.0" Condition="'$(ApplicationInsights)' == 'true'" />
     <PackageReference Include="Microsoft.AspNetCore.AzureAppServicesIntegration" Version="5.0.9" Condition="'$(Azure)' == 'true'" />
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="5.0.9" />
     <PackageReference Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.11.1" Condition="'$(Docker)' == 'true'" />
     <PackageReference Include="OpenTelemetry.Exporter.Console" Version="1.1.0" Condition="'$(OpenTelemetry)' == 'true'" />
     <PackageReference Include="OpenTelemetry.Extensions.Hosting" Version="1.0.0-rc7" Condition="'$(OpenTelemetry)' == 'true'" />

--- a/Source/GraphQLTemplate/Source/GraphQLTemplate/MvcBuilderExtensions.cs
+++ b/Source/GraphQLTemplate/Source/GraphQLTemplate/MvcBuilderExtensions.cs
@@ -1,36 +1,12 @@
 namespace GraphQLTemplate
 {
     using GraphQLTemplate.Options;
-    using Microsoft.AspNetCore.Hosting;
     using Microsoft.AspNetCore.Mvc.Formatters;
     using Microsoft.Extensions.Configuration;
     using Microsoft.Extensions.DependencyInjection;
-    using Microsoft.Extensions.Hosting;
-    using Newtonsoft.Json;
-    using Newtonsoft.Json.Converters;
 
     public static class MvcBuilderExtensions
     {
-        public static IMvcBuilder AddCustomJsonOptions(
-            this IMvcBuilder builder,
-            IWebHostEnvironment webHostEnvironment) =>
-            builder.AddNewtonsoftJson(
-                options =>
-                {
-                    if (webHostEnvironment.IsDevelopment())
-                    {
-                        // Pretty print the JSON in development for easier debugging.
-                        options.SerializerSettings.Formatting = Formatting.Indented;
-                    }
-
-                    // Parse dates as DateTimeOffset values by default. You should prefer using DateTimeOffset over
-                    // DateTime everywhere. Not doing so can cause problems with time-zones.
-                    options.SerializerSettings.DateParseHandling = DateParseHandling.DateTimeOffset;
-
-                    // Output enumeration values as strings in JSON.
-                    options.SerializerSettings.Converters.Add(new StringEnumConverter());
-                });
-
         public static IMvcBuilder AddCustomMvcOptions(this IMvcBuilder builder, IConfiguration configuration) =>
             builder.AddMvcOptions(
                 options =>

--- a/Source/GraphQLTemplate/Source/GraphQLTemplate/Startup.cs
+++ b/Source/GraphQLTemplate/Source/GraphQLTemplate/Startup.cs
@@ -68,7 +68,6 @@ namespace GraphQLTemplate
                 .AddHttpContextAccessor()
                 .AddServerTiming()
                 .AddControllers()
-                    .AddCustomJsonOptions(this.webHostEnvironment)
                     .AddCustomMvcOptions(this.configuration)
                 .Services
 #if Authorization


### PR DESCRIPTION
Fixes https://github.com/Dotnet-Boxed/Templates/issues/1199.

- Add `EnvironmentName.Test` to API template.
- Remove JSON serializer options from GraphQL template, since Hot Chocolate does not support it, see https://github.com/ChilliCream/hotchocolate/issues/4072.