### PR TITLE
Bump Microsoft.Orleans.* from 3.4.3 to 3.5.0

### DIFF
--- a/Source/OrleansTemplate/Source/OrleansTemplate.Abstractions/Grains/HealthChecks/ILocalHealthCheckGrain.cs
+++ b/Source/OrleansTemplate/Source/OrleansTemplate.Abstractions/Grains/HealthChecks/ILocalHealthCheckGrain.cs
@@ -5,6 +5,6 @@ namespace OrleansTemplate.Abstractions.Grains.HealthChecks
 
     public interface ILocalHealthCheckGrain : IGrainWithGuidKey
     {
-        Task CheckAsync();
+        ValueTask CheckAsync();
     }
 }

--- a/Source/OrleansTemplate/Source/OrleansTemplate.Abstractions/Grains/HealthChecks/IStorageHealthCheckGrain.cs
+++ b/Source/OrleansTemplate/Source/OrleansTemplate.Abstractions/Grains/HealthChecks/IStorageHealthCheckGrain.cs
@@ -5,6 +5,6 @@ namespace OrleansTemplate.Abstractions.Grains.HealthChecks
 
     public interface IStorageHealthCheckGrain : IGrainWithGuidKey
     {
-        Task CheckAsync();
+        ValueTask CheckAsync();
     }
 }

--- a/Source/OrleansTemplate/Source/OrleansTemplate.Abstractions/Grains/ICounterGrain.cs
+++ b/Source/OrleansTemplate/Source/OrleansTemplate.Abstractions/Grains/ICounterGrain.cs
@@ -10,8 +10,8 @@ namespace OrleansTemplate.Abstractions.Grains
     /// <seealso cref="IGrainWithGuidKey" />
     public interface ICounterGrain : IGrainWithGuidKey
     {
-        Task<long> AddCountAsync(long value);
+        ValueTask<long> AddCountAsync(long value);
 
-        Task<long> GetCountAsync();
+        ValueTask<long> GetCountAsync();
     }
 }

--- a/Source/OrleansTemplate/Source/OrleansTemplate.Abstractions/Grains/ICounterStatelessGrain.cs
+++ b/Source/OrleansTemplate/Source/OrleansTemplate.Abstractions/Grains/ICounterStatelessGrain.cs
@@ -10,6 +10,6 @@ namespace OrleansTemplate.Abstractions.Grains
     /// <seealso cref="IGrain" />
     public interface ICounterStatelessGrain : IGrainWithIntegerKey
     {
-        Task IncrementAsync();
+        ValueTask IncrementAsync();
     }
 }

--- a/Source/OrleansTemplate/Source/OrleansTemplate.Abstractions/Grains/IHelloGrain.cs
+++ b/Source/OrleansTemplate/Source/OrleansTemplate.Abstractions/Grains/IHelloGrain.cs
@@ -5,6 +5,6 @@ namespace OrleansTemplate.Abstractions.Grains
 
     public interface IHelloGrain : IGrainWithGuidKey
     {
-        Task<string> SayHelloAsync(string name);
+        ValueTask<string> SayHelloAsync(string name);
     }
 }

--- a/Source/OrleansTemplate/Source/OrleansTemplate.Abstractions/Grains/IReminderGrain.cs
+++ b/Source/OrleansTemplate/Source/OrleansTemplate.Abstractions/Grains/IReminderGrain.cs
@@ -5,6 +5,6 @@ namespace OrleansTemplate.Abstractions.Grains
 
     public interface IReminderGrain : IGrainWithGuidKey
     {
-        Task SetReminderAsync(string reminder);
+        ValueTask SetReminderAsync(string reminder);
     }
 }

--- a/Source/OrleansTemplate/Source/OrleansTemplate.Abstractions/OrleansTemplate.Abstractions.csproj
+++ b/Source/OrleansTemplate/Source/OrleansTemplate.Abstractions/OrleansTemplate.Abstractions.csproj
@@ -5,10 +5,10 @@
   </PropertyGroup>
 
   <ItemGroup Label="Package References">
-    <PackageReference Include="Microsoft.Orleans.CodeGenerator.MSBuild" PrivateAssets="all" Version="3.4.3">
+    <PackageReference Include="Microsoft.Orleans.CodeGenerator.MSBuild" PrivateAssets="all" Version="3.5.0">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.Orleans.Core.Abstractions" Version="3.4.3" />
+    <PackageReference Include="Microsoft.Orleans.Core.Abstractions" Version="3.5.0" />
     <PackageReference Include="System.Threading.Tasks.Extensions" Version="4.5.4" />
   </ItemGroup>
 

--- a/Source/OrleansTemplate/Source/OrleansTemplate.Client/OrleansTemplate.Client.csproj
+++ b/Source/OrleansTemplate/Source/OrleansTemplate.Client/OrleansTemplate.Client.csproj
@@ -15,12 +15,12 @@
 
   <ItemGroup Label="Package References">
     <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="5.0.0" />
-    <PackageReference Include="Microsoft.Orleans.Client" Version="3.4.3" />
-    <PackageReference Include="Microsoft.Orleans.Clustering.AzureStorage" Version="3.4.3" />
-    <PackageReference Include="Microsoft.Orleans.CodeGenerator.MSBuild" PrivateAssets="all" Version="3.4.3">
+    <PackageReference Include="Microsoft.Orleans.Client" Version="3.5.0" />
+    <PackageReference Include="Microsoft.Orleans.Clustering.AzureStorage" Version="3.5.0" />
+    <PackageReference Include="Microsoft.Orleans.CodeGenerator.MSBuild" PrivateAssets="all" Version="3.5.0">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.Orleans.Connections.Security" Version="3.4.3" Condition="'$(TLS)' == 'true'" />
+    <PackageReference Include="Microsoft.Orleans.Connections.Security" Version="3.5.0" Condition="'$(TLS)' == 'true'" />
   </ItemGroup>
 
   <ItemGroup Label="Project References">

--- a/Source/OrleansTemplate/Source/OrleansTemplate.Grains/CounterGrain.cs
+++ b/Source/OrleansTemplate/Source/OrleansTemplate.Grains/CounterGrain.cs
@@ -6,13 +6,13 @@ namespace OrleansTemplate.Grains
 
     public class CounterGrain : Grain<long>, ICounterGrain
     {
-        public async Task<long> AddCountAsync(long value)
+        public async ValueTask<long> AddCountAsync(long value)
         {
             this.State += value;
             await this.WriteStateAsync().ConfigureAwait(true);
             return this.State;
         }
 
-        public Task<long> GetCountAsync() => Task.FromResult(this.State);
+        public ValueTask<long> GetCountAsync() => ValueTask.FromResult(this.State);
     }
 }

--- a/Source/OrleansTemplate/Source/OrleansTemplate.Grains/CounterStatelessGrain.cs
+++ b/Source/OrleansTemplate/Source/OrleansTemplate.Grains/CounterStatelessGrain.cs
@@ -16,10 +16,10 @@ namespace OrleansTemplate.Grains
     {
         private long count;
 
-        public Task IncrementAsync()
+        public ValueTask IncrementAsync()
         {
             this.count += 1;
-            return Task.CompletedTask;
+            return ValueTask.CompletedTask;
         }
 
         public override Task OnActivateAsync()
@@ -30,12 +30,12 @@ namespace OrleansTemplate.Grains
             return base.OnActivateAsync();
         }
 
-        private Task OnTimerTickAsync(object arg)
+        private async Task OnTimerTickAsync(object arg)
         {
             var count = this.count;
             this.count = 0;
             var counter = this.GrainFactory.GetGrain<ICounterGrain>(Guid.Empty);
-            return counter.AddCountAsync(count);
+            await counter.AddCountAsync(count).ConfigureAwait(true);
         }
     }
 }

--- a/Source/OrleansTemplate/Source/OrleansTemplate.Grains/HealthChecks/LocalHealthCheckGrain.cs
+++ b/Source/OrleansTemplate/Source/OrleansTemplate.Grains/HealthChecks/LocalHealthCheckGrain.cs
@@ -8,6 +8,6 @@ namespace OrleansTemplate.Grains
     [StatelessWorker(1)]
     public class LocalHealthCheckGrain : Grain, ILocalHealthCheckGrain
     {
-        public Task CheckAsync() => Task.CompletedTask;
+        public ValueTask CheckAsync() => ValueTask.CompletedTask;
     }
 }

--- a/Source/OrleansTemplate/Source/OrleansTemplate.Grains/HealthChecks/StorageHealthCheckGrain.cs
+++ b/Source/OrleansTemplate/Source/OrleansTemplate.Grains/HealthChecks/StorageHealthCheckGrain.cs
@@ -10,7 +10,7 @@ namespace OrleansTemplate.Grains.HealthChecks
     [PreferLocalPlacement]
     public class StorageHealthCheckGrain : Grain<Guid>, IStorageHealthCheckGrain
     {
-        public async Task CheckAsync()
+        public async ValueTask CheckAsync()
         {
             try
             {

--- a/Source/OrleansTemplate/Source/OrleansTemplate.Grains/HelloGrain.cs
+++ b/Source/OrleansTemplate/Source/OrleansTemplate.Grains/HelloGrain.cs
@@ -8,7 +8,7 @@ namespace OrleansTemplate.Grains
 
     public class HelloGrain : Grain, IHelloGrain
     {
-        public async Task<string> SayHelloAsync(string name)
+        public async ValueTask<string> SayHelloAsync(string name)
         {
             await this.IncrementCounterAsync().ConfigureAwait(true);
             await this.PublishSaidHelloAsync(name).ConfigureAwait(true);
@@ -16,7 +16,7 @@ namespace OrleansTemplate.Grains
             return $"Hello {name}!";
         }
 
-        private Task IncrementCounterAsync()
+        private ValueTask IncrementCounterAsync()
         {
             var counter = this.GrainFactory.GetGrain<ICounterStatelessGrain>(0L);
             return counter.IncrementAsync();

--- a/Source/OrleansTemplate/Source/OrleansTemplate.Grains/OrleansTemplate.Grains.csproj
+++ b/Source/OrleansTemplate/Source/OrleansTemplate.Grains/OrleansTemplate.Grains.csproj
@@ -5,10 +5,10 @@
   </PropertyGroup>
 
   <ItemGroup Label="Package References">
-    <PackageReference Include="Microsoft.Orleans.CodeGenerator.MSBuild" PrivateAssets="all" Version="3.4.3">
+    <PackageReference Include="Microsoft.Orleans.CodeGenerator.MSBuild" PrivateAssets="all" Version="3.5.0">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.Orleans.Core" Version="3.4.3" />
+    <PackageReference Include="Microsoft.Orleans.Core" Version="3.5.0" />
     <PackageReference Include="System.Threading.Tasks.Extensions" Version="4.5.4" />
   </ItemGroup>
 

--- a/Source/OrleansTemplate/Source/OrleansTemplate.Grains/ReminderGrain.cs
+++ b/Source/OrleansTemplate/Source/OrleansTemplate.Grains/ReminderGrain.cs
@@ -12,10 +12,10 @@ namespace OrleansTemplate.Grains
         private const string ReminderName = "SomeReminder";
         private string? reminder;
 
-        public Task SetReminderAsync(string reminder)
+        public ValueTask SetReminderAsync(string reminder)
         {
             this.reminder = reminder;
-            return Task.CompletedTask;
+            return ValueTask.CompletedTask;
         }
 
         public override async Task OnActivateAsync()

--- a/Source/OrleansTemplate/Source/OrleansTemplate.Server/OrleansTemplate.Server.csproj
+++ b/Source/OrleansTemplate/Source/OrleansTemplate.Server/OrleansTemplate.Server.csproj
@@ -42,19 +42,19 @@
     <PackageReference Include="Microsoft.Extensions.Configuration.CommandLine" Version="5.0.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="5.0.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration.UserSecrets" Version="5.0.0" />
-    <PackageReference Include="Microsoft.Orleans.Clustering.AzureStorage" Version="3.4.3" />
-    <PackageReference Include="Microsoft.Orleans.CodeGenerator.MSBuild" PrivateAssets="all" Version="3.4.3">
+    <PackageReference Include="Microsoft.Orleans.Clustering.AzureStorage" Version="3.5.0" />
+    <PackageReference Include="Microsoft.Orleans.CodeGenerator.MSBuild" PrivateAssets="all" Version="3.5.0">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.Orleans.Connections.Security" Version="3.4.3" Condition="'$(TLS)' == 'true'" />
-    <PackageReference Include="Microsoft.Orleans.OrleansTelemetryConsumers.AI" Version="3.4.3" Condition="'$(ApplicationInsights)' == 'true'" />
-    <PackageReference Include="Microsoft.Orleans.OrleansTelemetryConsumers.Counters" Version="3.4.3" />
-    <PackageReference Include="Microsoft.Orleans.OrleansTelemetryConsumers.Linux" Version="3.4.3" />
-    <PackageReference Include="Microsoft.Orleans.Persistence.AzureStorage" Version="3.4.3" />
-    <PackageReference Include="Microsoft.Orleans.Reminders.AzureStorage" Version="3.4.3" />
-    <PackageReference Include="Microsoft.Orleans.Server" Version="3.4.3" />
-    <PackageReference Include="Microsoft.Orleans.Transactions" Version="3.4.3" />
-    <PackageReference Include="Microsoft.Orleans.Transactions.AzureStorage" Version="3.4.3" />
+    <PackageReference Include="Microsoft.Orleans.Connections.Security" Version="3.5.0" Condition="'$(TLS)' == 'true'" />
+    <PackageReference Include="Microsoft.Orleans.OrleansTelemetryConsumers.AI" Version="3.5.0" Condition="'$(ApplicationInsights)' == 'true'" />
+    <PackageReference Include="Microsoft.Orleans.OrleansTelemetryConsumers.Counters" Version="3.5.0" />
+    <PackageReference Include="Microsoft.Orleans.OrleansTelemetryConsumers.Linux" Version="3.5.0" />
+    <PackageReference Include="Microsoft.Orleans.Persistence.AzureStorage" Version="3.5.0" />
+    <PackageReference Include="Microsoft.Orleans.Reminders.AzureStorage" Version="3.5.0" />
+    <PackageReference Include="Microsoft.Orleans.Server" Version="3.5.0" />
+    <PackageReference Include="Microsoft.Orleans.Transactions" Version="3.5.0" />
+    <PackageReference Include="Microsoft.Orleans.Transactions.AzureStorage" Version="3.5.0" />
     <PackageReference Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.11.1" Condition="'$(Docker)' == 'true'" />
     <PackageReference Include="OpenTelemetry.Exporter.Console" Version="1.1.0" Condition="'$(OpenTelemetry)' == 'true'" />
     <PackageReference Include="OpenTelemetry.Extensions.Hosting" Version="1.0.0-rc7" Condition="'$(OpenTelemetry)' == 'true'" />

--- a/Source/OrleansTemplate/Source/OrleansTemplate.Server/OrleansTemplate.Server.csproj
+++ b/Source/OrleansTemplate/Source/OrleansTemplate.Server/OrleansTemplate.Server.csproj
@@ -39,6 +39,7 @@
 
   <ItemGroup Label="Package References">
     <PackageReference Include="OrleansDashboard" Version="3.5.2" />
+    <PackageReference Include="Microsoft.ApplicationInsights.AspNetCore" Version="2.18.0" Condition="'$(ApplicationInsights)' == 'true'" />
     <PackageReference Include="Microsoft.Extensions.Configuration.CommandLine" Version="5.0.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="5.0.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration.UserSecrets" Version="5.0.0" />

--- a/Source/OrleansTemplate/Source/OrleansTemplate.Server/Program.cs
+++ b/Source/OrleansTemplate/Source/OrleansTemplate.Server/Program.cs
@@ -207,6 +207,11 @@ namespace OrleansTemplate.Server
                 // override the ones in all of the above config files. See
                 // http://docs.asp.net/en/latest/security/app-secrets.html
                 .AddEnvironmentVariables()
+#if ApplicationInsights
+                // Push telemetry data through the Azure Application Insights pipeline faster in the development and
+                // staging environments, allowing you to view results immediately.
+                .AddApplicationInsightsSettings(developerMode: !hostEnvironment.IsProduction())
+#endif
                 // Add command line options. These take the highest priority.
                 .AddIf(
                     args is not null,

--- a/Source/OrleansTemplate/Source/OrleansTemplate.Server/Startup.cs
+++ b/Source/OrleansTemplate/Source/OrleansTemplate.Server/Startup.cs
@@ -29,6 +29,10 @@ namespace OrleansTemplate.Server
 
         public virtual void ConfigureServices(IServiceCollection services) =>
             services
+#if ApplicationInsights
+                // Add Azure Application Insights data collection services to the services container.
+                .AddApplicationInsightsTelemetry(this.configuration)
+#endif
                 .AddRouting()
 #if OpenTelemetry
                 .AddCustomOpenTelemetryTracing(this.webHostEnvironment)

--- a/Source/OrleansTemplate/Tests/OrleansTemplate.Server.IntegrationTest/OrleansTemplate.Server.IntegrationTest.csproj
+++ b/Source/OrleansTemplate/Tests/OrleansTemplate.Server.IntegrationTest/OrleansTemplate.Server.IntegrationTest.csproj
@@ -17,7 +17,7 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.11.0" />
-    <PackageReference Include="Microsoft.Orleans.TestingHost" Version="3.4.3" />
+    <PackageReference Include="Microsoft.Orleans.TestingHost" Version="3.5.0" />
     <PackageReference Include="Serilog.Extensions.Logging" Version="3.0.1" Condition="'$(Serilog)' == 'true'" />
     <PackageReference Include="Serilog.Sinks.Debug" Version="2.0.0" Condition="'$(Serilog)' == 'true'" />
     <PackageReference Include="Serilog.Sinks.XUnit" Version="2.0.4" Condition="'$(Serilog)' == 'true'" />


### PR DESCRIPTION
- Also switches from `Task` to `ValueTask`.
- Fixes Application Insights option.