### PR TITLE
Cache NuGet Packages in Docker Builds

### DIFF
--- a/Source/ApiTemplate/Source/ApiTemplate/Dockerfile
+++ b/Source/ApiTemplate/Source/ApiTemplate/Dockerfile
@@ -43,7 +43,9 @@ WORKDIR /src
 COPY "ApiTemplate.sln" "."
 COPY "Source/ApiTemplate/*.csproj" "Source/ApiTemplate/"
 COPY "Tests/ApiTemplate.IntegrationTest/*.csproj" "Tests/ApiTemplate.IntegrationTest/"
-RUN dotnet restore
+# Run the restore and cache the packages on the host for faster subsequent builds.
+RUN --mount=type=cache,id=nuget,target=/root/.nuget/packages /
+    dotnet restore
 COPY . .
 # To view the files that have been copied into the container file system for debugging purposes uncomment this line
 # RUN apk add --no-cache tree && tree

--- a/Source/GraphQLTemplate/Source/GraphQLTemplate/Dockerfile
+++ b/Source/GraphQLTemplate/Source/GraphQLTemplate/Dockerfile
@@ -43,7 +43,9 @@ WORKDIR /src
 COPY "GraphQLTemplate.sln" "."
 COPY "Source/GraphQLTemplate/*.csproj" "Source/GraphQLTemplate/"
 COPY "Tests/GraphQLTemplate.IntegrationTest/*.csproj" "Tests/GraphQLTemplate.IntegrationTest/"
-RUN dotnet restore
+# Run the restore and cache the packages on the host for faster subsequent builds.
+RUN --mount=type=cache,id=nuget,target=/root/.nuget/packages /
+    dotnet restore
 COPY . .
 # To view the files that have been copied into the container file system for debugging purposes uncomment this line
 # RUN apk add --no-cache tree && tree

--- a/Source/OrleansTemplate/Source/OrleansTemplate.Server/Dockerfile
+++ b/Source/OrleansTemplate/Source/OrleansTemplate.Server/Dockerfile
@@ -42,7 +42,9 @@ COPY "Source/OrleansTemplate.Client/*.csproj" "Source/OrleansTemplate.Client/"
 COPY "Source/OrleansTemplate.Grains/*.csproj" "Source/OrleansTemplate.Grains/"
 COPY "Source/OrleansTemplate.Server/*.csproj" "Source/OrleansTemplate.Server/"
 COPY "Tests/OrleansTemplate.Server.IntegrationTest/*.csproj" "Tests/OrleansTemplate.Server.IntegrationTest/"
-RUN dotnet restore
+# Run the restore and cache the packages on the host for faster subsequent builds.
+RUN --mount=type=cache,id=nuget,target=/root/.nuget/packages /
+    dotnet restore
 COPY . .
 # To view the files that have been copied into the container file system for debugging purposes uncomment this line
 # RUN apk add --no-cache tree && tree


### PR DESCRIPTION
See:

- https://github.com/dotnet/dotnet-docker/issues/2457
- https://stackoverflow.com/questions/69464184/using-docker-buildkit-mount-type-cache-for-caching-nuget-packages-for-net-5-d