### PR TITLE
Remove Docker buildx --mount=type=cache

### DIFF
--- a/Source/ApiTemplate/Source/ApiTemplate/Dockerfile
+++ b/Source/ApiTemplate/Source/ApiTemplate/Dockerfile
@@ -44,8 +44,7 @@ COPY "ApiTemplate.sln" "."
 COPY "Source/ApiTemplate/*.csproj" "Source/ApiTemplate/"
 COPY "Tests/ApiTemplate.IntegrationTest/*.csproj" "Tests/ApiTemplate.IntegrationTest/"
 # Run the restore and cache the packages on the host for faster subsequent builds.
-RUN --mount=type=cache,id=nuget,target=/root/.nuget/packages /
-    dotnet restore
+RUN dotnet restore
 COPY . .
 # To view the files that have been copied into the container file system for debugging purposes uncomment this line
 # RUN apk add --no-cache tree && tree

--- a/Source/GraphQLTemplate/Source/GraphQLTemplate/Dockerfile
+++ b/Source/GraphQLTemplate/Source/GraphQLTemplate/Dockerfile
@@ -44,8 +44,7 @@ COPY "GraphQLTemplate.sln" "."
 COPY "Source/GraphQLTemplate/*.csproj" "Source/GraphQLTemplate/"
 COPY "Tests/GraphQLTemplate.IntegrationTest/*.csproj" "Tests/GraphQLTemplate.IntegrationTest/"
 # Run the restore and cache the packages on the host for faster subsequent builds.
-RUN --mount=type=cache,id=nuget,target=/root/.nuget/packages /
-    dotnet restore
+RUN dotnet restore
 COPY . .
 # To view the files that have been copied into the container file system for debugging purposes uncomment this line
 # RUN apk add --no-cache tree && tree

--- a/Source/OrleansTemplate/Source/OrleansTemplate.Server/Dockerfile
+++ b/Source/OrleansTemplate/Source/OrleansTemplate.Server/Dockerfile
@@ -43,8 +43,7 @@ COPY "Source/OrleansTemplate.Grains/*.csproj" "Source/OrleansTemplate.Grains/"
 COPY "Source/OrleansTemplate.Server/*.csproj" "Source/OrleansTemplate.Server/"
 COPY "Tests/OrleansTemplate.Server.IntegrationTest/*.csproj" "Tests/OrleansTemplate.Server.IntegrationTest/"
 # Run the restore and cache the packages on the host for faster subsequent builds.
-RUN --mount=type=cache,id=nuget,target=/root/.nuget/packages /
-    dotnet restore
+RUN dotnet restore
 COPY . .
 # To view the files that have been copied into the container file system for debugging purposes uncomment this line
 # RUN apk add --no-cache tree && tree


### PR DESCRIPTION
See https://stackoverflow.com/questions/70181870/docker-buildkit-mount-type-cache-for-caching-nuget-packages-for-net-6