### PR TITLE
Ignore `.devcontainer` DockerFiles in cake builds.

### DIFF
--- a/Source/ApiTemplate/build.cake
+++ b/Source/ApiTemplate/build.cake
@@ -89,7 +89,10 @@ Task("DockerBuild")
     .Description("Builds a Docker image.")
     .DoesForEach(GetFiles("./**/Dockerfile"), dockerfile =>
     {
-        tag = tag ?? dockerfile.GetDirectory().GetDirectoryName().ToLower();
+        var imageName = dockerfile.GetDirectory().GetDirectoryName().ToLower();
+        if(imageName == ".devcontainer") return;
+        tag = tag ?? imageName;
+        
         var version = GetVersion();
         var gitCommitSha = GetGitCommitSha();
 

--- a/Source/OrleansTemplate/build.cake
+++ b/Source/OrleansTemplate/build.cake
@@ -89,7 +89,10 @@ Task("DockerBuild")
     .Description("Builds a Docker image.")
     .DoesForEach(GetFiles("./**/Dockerfile"), dockerfile =>
     {
-        tag = tag ?? dockerfile.GetDirectory().GetDirectoryName().ToLower();
+        var imageName = dockerfile.GetDirectory().GetDirectoryName().ToLower();
+        if(imageName == ".devcontainer") return;
+        tag = tag ?? imageName;
+        
         var version = GetVersion();
         var gitCommitSha = GetGitCommitSha();
 


### PR DESCRIPTION
Currently if you use a Dev Container, the cake build picks it up.


Resolves https://github.com/Dotnet-Boxed/Templates/issues/1704