### PR TITLE
Update to FluentValidation 11.2.1

### DIFF
--- a/Source/ApiTemplate/Source/ApiTemplate/ApiTemplate.csproj
+++ b/Source/ApiTemplate/Source/ApiTemplate/ApiTemplate.csproj
@@ -55,7 +55,7 @@
     <PackageReference Include="Boxed.AspNetCore" Version="8.0.0" />
     <PackageReference Include="Boxed.AspNetCore.Swagger" Version="10.0.0" Condition="'$(Swagger)' == 'true'" />
     <PackageReference Include="Boxed.Mapping" Version="6.0.0" />
-    <PackageReference Include="FluentValidation.AspNetCore" Version="11.1.2" />
+    <PackageReference Include="FluentValidation.AspNetCore" Version="11.2.1" />
     <PackageReference Include="Microsoft.ApplicationInsights.AspNetCore" Version="2.21.0" Condition="'$(ApplicationInsights)' == 'true'" />
     <PackageReference Include="Microsoft.AspNetCore.ApplicationInsights.HostingStartup" Version="2.2.0" Condition="'$(ApplicationInsights)' == 'true'" />
     <PackageReference Include="Microsoft.AspNetCore.AzureAppServicesIntegration" Version="6.0.8" Condition="'$(Azure)' == 'true'" />

--- a/Source/ApiTemplate/Source/ApiTemplate/Commands/GetCarPageCommand.cs
+++ b/Source/ApiTemplate/Source/ApiTemplate/Commands/GetCarPageCommand.cs
@@ -43,7 +43,7 @@ public class GetCarPageCommand
         {
             var modelState = this.actionContextAccessor.ActionContext!.ModelState;
             validationResult.AddToModelState(modelState, null);
-            return new BadRequestObjectResult(modelState);
+            return new BadRequestObjectResult(new ValidationProblemDetails(modelState));
         }
 
         pageOptions.First = !pageOptions.First.HasValue && !pageOptions.Last.HasValue ? DefaultPageSize : pageOptions.First;

--- a/Source/ApiTemplate/Source/ApiTemplate/Commands/PatchCarCommand.cs
+++ b/Source/ApiTemplate/Source/ApiTemplate/Commands/PatchCarCommand.cs
@@ -52,7 +52,7 @@ public class PatchCarCommand
         if (!validationResult.IsValid)
         {
             validationResult.AddToModelState(modelState, null);
-            return new BadRequestObjectResult(modelState);
+            return new BadRequestObjectResult(new ValidationProblemDetails(modelState));
         }
 
         this.saveCarToCarMapper.Map(saveCar, car);

--- a/Source/ApiTemplate/Source/ApiTemplate/Commands/PatchCarCommand.cs
+++ b/Source/ApiTemplate/Source/ApiTemplate/Commands/PatchCarCommand.cs
@@ -3,34 +3,35 @@ namespace ApiTemplate.Commands;
 using ApiTemplate.Repositories;
 using ApiTemplate.ViewModels;
 using Boxed.Mapping;
+using FluentValidation;
+using FluentValidation.AspNetCore;
 using Microsoft.AspNetCore.JsonPatch;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.Infrastructure;
-using Microsoft.AspNetCore.Mvc.ModelBinding.Validation;
 
 public class PatchCarCommand
 {
     private readonly IActionContextAccessor actionContextAccessor;
-    private readonly IObjectModelValidator objectModelValidator;
     private readonly ICarRepository carRepository;
     private readonly IMapper<Models.Car, Car> carToCarMapper;
     private readonly IMapper<Models.Car, SaveCar> carToSaveCarMapper;
     private readonly IMapper<SaveCar, Models.Car> saveCarToCarMapper;
+    private readonly IValidator<SaveCar> saveCarValidator;
 
     public PatchCarCommand(
         IActionContextAccessor actionContextAccessor,
-        IObjectModelValidator objectModelValidator,
         ICarRepository carRepository,
         IMapper<Models.Car, Car> carToCarMapper,
         IMapper<Models.Car, SaveCar> carToSaveCarMapper,
-        IMapper<SaveCar, Models.Car> saveCarToCarMapper)
+        IMapper<SaveCar, Models.Car> saveCarToCarMapper,
+        IValidator<SaveCar> saveCarValidator)
     {
         this.actionContextAccessor = actionContextAccessor;
-        this.objectModelValidator = objectModelValidator;
         this.carRepository = carRepository;
         this.carToCarMapper = carToCarMapper;
         this.carToSaveCarMapper = carToSaveCarMapper;
         this.saveCarToCarMapper = saveCarToCarMapper;
+        this.saveCarValidator = saveCarValidator;
     }
 
     public async Task<IActionResult> ExecuteAsync(
@@ -47,13 +48,10 @@ public class PatchCarCommand
         var saveCar = this.carToSaveCarMapper.Map(car);
         var modelState = this.actionContextAccessor.ActionContext!.ModelState;
         patch.ApplyTo(saveCar, modelState);
-        this.objectModelValidator.Validate(
-            this.actionContextAccessor.ActionContext,
-            validationState: null,
-            prefix: string.Empty,
-            model: saveCar);
-        if (!modelState.IsValid)
+        var validationResult = this.saveCarValidator.Validate(saveCar);
+        if (!validationResult.IsValid)
         {
+            validationResult.AddToModelState(modelState, null);
             return new BadRequestObjectResult(modelState);
         }
 

--- a/Source/ApiTemplate/Source/ApiTemplate/Commands/PostCarCommand.cs
+++ b/Source/ApiTemplate/Source/ApiTemplate/Commands/PostCarCommand.cs
@@ -38,7 +38,7 @@ public class PostCarCommand
         {
             var modelState = this.actionContextAccessor.ActionContext!.ModelState;
             validationResult.AddToModelState(modelState, null);
-            return new BadRequestObjectResult(modelState);
+            return new BadRequestObjectResult(new ValidationProblemDetails(modelState));
         }
 
         var car = this.saveCarToCarMapper.Map(saveCar);

--- a/Source/ApiTemplate/Source/ApiTemplate/Commands/PostCarCommand.cs
+++ b/Source/ApiTemplate/Source/ApiTemplate/Commands/PostCarCommand.cs
@@ -4,26 +4,43 @@ using ApiTemplate.Constants;
 using ApiTemplate.Repositories;
 using ApiTemplate.ViewModels;
 using Boxed.Mapping;
+using FluentValidation;
+using FluentValidation.AspNetCore;
 using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.Infrastructure;
 
 public class PostCarCommand
 {
+    private readonly IActionContextAccessor actionContextAccessor;
     private readonly ICarRepository carRepository;
     private readonly IMapper<Models.Car, Car> carToCarMapper;
     private readonly IMapper<SaveCar, Models.Car> saveCarToCarMapper;
+    private readonly IValidator<SaveCar> saveCarValidator;
 
     public PostCarCommand(
+        IActionContextAccessor actionContextAccessor,
         ICarRepository carRepository,
         IMapper<Models.Car, Car> carToCarMapper,
-        IMapper<SaveCar, Models.Car> saveCarToCarMapper)
+        IMapper<SaveCar, Models.Car> saveCarToCarMapper,
+        IValidator<SaveCar> saveCarValidator)
     {
+        this.actionContextAccessor = actionContextAccessor;
         this.carRepository = carRepository;
         this.carToCarMapper = carToCarMapper;
         this.saveCarToCarMapper = saveCarToCarMapper;
+        this.saveCarValidator = saveCarValidator;
     }
 
     public async Task<IActionResult> ExecuteAsync(SaveCar saveCar, CancellationToken cancellationToken)
     {
+        var validationResult = this.saveCarValidator.Validate(saveCar);
+        if (!validationResult.IsValid)
+        {
+            var modelState = this.actionContextAccessor.ActionContext!.ModelState;
+            validationResult.AddToModelState(modelState, null);
+            return new BadRequestObjectResult(modelState);
+        }
+
         var car = this.saveCarToCarMapper.Map(saveCar);
         car = await this.carRepository.AddAsync(car, cancellationToken).ConfigureAwait(false);
         var carViewModel = this.carToCarMapper.Map(car);

--- a/Source/ApiTemplate/Source/ApiTemplate/Commands/PutCarCommand.cs
+++ b/Source/ApiTemplate/Source/ApiTemplate/Commands/PutCarCommand.cs
@@ -37,7 +37,7 @@ public class PutCarCommand
         {
             var modelState = this.actionContextAccessor.ActionContext!.ModelState;
             validationResult.AddToModelState(modelState, null);
-            return new BadRequestObjectResult(modelState);
+            return new BadRequestObjectResult(new ValidationProblemDetails(modelState));
         }
 
         var car = await this.carRepository.GetAsync(carId, cancellationToken).ConfigureAwait(false);

--- a/Source/ApiTemplate/Source/ApiTemplate/Commands/PutCarCommand.cs
+++ b/Source/ApiTemplate/Source/ApiTemplate/Commands/PutCarCommand.cs
@@ -3,26 +3,43 @@ namespace ApiTemplate.Commands;
 using ApiTemplate.Repositories;
 using ApiTemplate.ViewModels;
 using Boxed.Mapping;
+using FluentValidation;
+using FluentValidation.AspNetCore;
 using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.Infrastructure;
 
 public class PutCarCommand
 {
+    private readonly IActionContextAccessor actionContextAccessor;
     private readonly ICarRepository carRepository;
     private readonly IMapper<Models.Car, Car> carToCarMapper;
     private readonly IMapper<SaveCar, Models.Car> saveCarToCarMapper;
+    private readonly IValidator<SaveCar> saveCarValidator;
 
     public PutCarCommand(
+        IActionContextAccessor actionContextAccessor,
         ICarRepository carRepository,
         IMapper<Models.Car, Car> carToCarMapper,
-        IMapper<SaveCar, Models.Car> saveCarToCarMapper)
+        IMapper<SaveCar, Models.Car> saveCarToCarMapper,
+        IValidator<SaveCar> saveCarValidator)
     {
+        this.actionContextAccessor = actionContextAccessor;
         this.carRepository = carRepository;
         this.carToCarMapper = carToCarMapper;
         this.saveCarToCarMapper = saveCarToCarMapper;
+        this.saveCarValidator = saveCarValidator;
     }
 
     public async Task<IActionResult> ExecuteAsync(int carId, SaveCar saveCar, CancellationToken cancellationToken)
     {
+        var validationResult = this.saveCarValidator.Validate(saveCar);
+        if (!validationResult.IsValid)
+        {
+            var modelState = this.actionContextAccessor.ActionContext!.ModelState;
+            validationResult.AddToModelState(modelState, null);
+            return new BadRequestObjectResult(modelState);
+        }
+
         var car = await this.carRepository.GetAsync(carId, cancellationToken).ConfigureAwait(false);
         if (car is null)
         {

--- a/Source/ApiTemplate/Source/ApiTemplate/CustomServiceCollectionExtensions.cs
+++ b/Source/ApiTemplate/Source/ApiTemplate/CustomServiceCollectionExtensions.cs
@@ -6,9 +6,6 @@ using ApiTemplate.Constants;
 #endif
 using ApiTemplate.Options;
 using Boxed.AspNetCore;
-#if Controllers
-using FluentValidation.AspNetCore;
-#endif
 #if (!ForwardedHeaders && HostFiltering)
 using Microsoft.AspNetCore.HostFiltering;
 #endif
@@ -20,17 +17,6 @@ using Microsoft.Extensions.Options;
 /// </summary>
 internal static class CustomServiceCollectionExtensions
 {
-#if Controllers
-    public static IServiceCollection AddCustomFluentValidation(this IServiceCollection services) =>
-        services
-            .AddFluentValidation(
-                x =>
-                {
-                    x.RegisterValidatorsFromAssemblyContaining<Startup>(lifetime: ServiceLifetime.Singleton);
-                    x.DisableDataAnnotationsValidation = true;
-                });
-
-#endif
     /// <summary>
     /// Configures the settings by binding the contents of the appsettings.json file to the specified Plain Old CLR
     /// Objects (POCO) and adding <see cref="IOptions{T}"/> objects to the services collection.

--- a/Source/ApiTemplate/Source/ApiTemplate/Startup.cs
+++ b/Source/ApiTemplate/Source/ApiTemplate/Startup.cs
@@ -4,7 +4,9 @@ namespace ApiTemplate;
 using ApiTemplate.Constants;
 #endif
 using Boxed.AspNetCore;
+#if Controllers
 using FluentValidation;
+#endif
 #if HealthCheck
 using Microsoft.AspNetCore.Diagnostics.HealthChecks;
 #endif

--- a/Source/ApiTemplate/Source/ApiTemplate/Startup.cs
+++ b/Source/ApiTemplate/Source/ApiTemplate/Startup.cs
@@ -4,6 +4,7 @@ namespace ApiTemplate;
 using ApiTemplate.Constants;
 #endif
 using Boxed.AspNetCore;
+using FluentValidation;
 #if HealthCheck
 using Microsoft.AspNetCore.Diagnostics.HealthChecks;
 #endif
@@ -85,8 +86,8 @@ public class Startup
 #endif
             .AddServerTiming()
 #if Controllers
-            .AddCustomFluentValidation()
-            .AddControllers()
+            .AddValidatorsFromAssemblyContaining<Startup>(lifetime: ServiceLifetime.Singleton)
+            .AddControllers(x => x.ModelValidatorProviders.Clear())
 #if DataContractSerializer
             // Adds the XML input and output formatter using the DataContractSerializer.
             .AddXmlDataContractSerializerFormatters()

--- a/Source/ApiTemplate/Tests/ApiTemplate.IntegrationTest/Controllers/CarsControllerTest.cs
+++ b/Source/ApiTemplate/Tests/ApiTemplate.IntegrationTest/Controllers/CarsControllerTest.cs
@@ -115,7 +115,11 @@ public class CarsControllerTest : CustomWebApplicationFactory<Program>
         Assert.Equal(4, carViewModel.Cylinders);
         Assert.Equal("Honda", carViewModel.Make);
         Assert.Equal("Civic", carViewModel.Model);
+#if HttpsEverywhere
         Assert.Equal(new Uri("https://localhost/cars/1"), carViewModel.Url);
+#else
+        Assert.Equal(new Uri("http://localhost/cars/1"), carViewModel.Url);
+#endif
     }
 
     [Fact]
@@ -395,7 +399,11 @@ public class CarsControllerTest : CustomWebApplicationFactory<Program>
         Assert.Equal(4, carViewModel.Cylinders);
         Assert.Equal("Honda", carViewModel.Make);
         Assert.Equal("Civic", carViewModel.Model);
+#if HttpsEverywhere
         Assert.Equal(new Uri("https://localhost/cars/1"), carViewModel.Url);
+#else
+        Assert.Equal(new Uri("http://localhost/cars/1"), carViewModel.Url);
+#endif
     }
 
     [Fact]
@@ -481,7 +489,11 @@ public class CarsControllerTest : CustomWebApplicationFactory<Program>
         Assert.Equal(4, carViewModel.Cylinders);
         Assert.Equal("Honda", carViewModel.Make);
         Assert.Equal("Civic", carViewModel.Model);
+#if HttpsEverywhere
         Assert.Equal(new Uri("https://localhost/cars/1"), carViewModel.Url);
+#else
+        Assert.Equal(new Uri("http://localhost/cars/1"), carViewModel.Url);
+#endif
     }
 
     [Fact]
@@ -587,7 +599,11 @@ public class CarsControllerTest : CustomWebApplicationFactory<Program>
         Assert.Equal(4, carViewModel.Cylinders);
         Assert.Equal("Honda", carViewModel.Make);
         Assert.Equal("Civic Type-R", carViewModel.Model);
+#if HttpsEverywhere
         Assert.Equal(new Uri("https://localhost/cars/1"), carViewModel.Url);
+#else
+        Assert.Equal(new Uri("http://localhost/cars/1"), carViewModel.Url);
+#endif
     }
 
     private static List<Models.Car> GetCars() =>


### PR DESCRIPTION
- Validation is now done manually as per the recommendation from `FluentValidation`.
- This sets us up nicely for the switch to minimal API's in .NET 7.