### PR TITLE
Ignore Dockerfile's in .devcontainer folders

### DIFF
--- a/Source/ApiTemplate/build.cake
+++ b/Source/ApiTemplate/build.cake
@@ -13,10 +13,7 @@ var push =
     HasArgument("Push") ? Argument<bool>("Push") :
     EnvironmentVariable("Push", false);
 #endif
-#if (Docker)
-// Add directory names to exclude from the DockerBuild
-var foldersToExcludeFromDockerfileBuild = new[] { ".devcontainer" };
-#endif
+
 var artefactsDirectory = Directory("./Artefacts");
 
 Task("Clean")
@@ -52,133 +49,129 @@ Task("Build")
 
 Task("Test")
     .Description("Runs unit tests and outputs test results to the artefacts directory.")
-    .DoesForEach(GetFiles("./Tests/**/*.csproj"), project =>
-    {
-        DotNetTest(
-            project.ToString(),
-            new DotNetTestSettings()
-            {
-                Blame = true,
-                Collectors = new string[] { "Code Coverage", "XPlat Code Coverage" },
-                Configuration = configuration,
-                Loggers = new string[]
+    .DoesForEach(
+        GetFiles("./Tests/**/*.csproj"),
+        project =>
+        {
+            DotNetTest(
+                project.ToString(),
+                new DotNetTestSettings()
                 {
-                    $"trx;LogFileName={project.GetFilenameWithoutExtension()}.trx",
-                    $"html;LogFileName={project.GetFilenameWithoutExtension()}.html",
-                },
-                NoBuild = true,
-                NoRestore = true,
-                ResultsDirectory = artefactsDirectory,
-            });
-    });
+                    Blame = true,
+                    Collectors = new string[] { "Code Coverage", "XPlat Code Coverage" },
+                    Configuration = configuration,
+                    Loggers = new string[]
+                    {
+                        $"trx;LogFileName={project.GetFilenameWithoutExtension()}.trx",
+                        $"html;LogFileName={project.GetFilenameWithoutExtension()}.html",
+                    },
+                    NoBuild = true,
+                    NoRestore = true,
+                    ResultsDirectory = artefactsDirectory,
+                });
+        });
 
 Task("Publish")
     .Description("Publishes the solution.")
-    .DoesForEach(GetFiles("./Source/**/*.csproj"), project =>
-    {
-        DotNetPublish(
-            project.ToString(),
-            new DotNetPublishSettings()
-            {
-                Configuration = configuration,
-                NoBuild = true,
-                NoRestore = true,
-                OutputDirectory = artefactsDirectory + Directory("Publish"),
-            });
-    });
+    .DoesForEach(
+        GetFiles("./Source/**/*.csproj"),
+        project =>
+        {
+            DotNetPublish(
+                project.ToString(),
+                new DotNetPublishSettings()
+                {
+                    Configuration = configuration,
+                    NoBuild = true,
+                    NoRestore = true,
+                    OutputDirectory = artefactsDirectory + Directory("Publish"),
+                });
+        });
 
 #if (Docker)
-
-Func<IFileSystemInfo, bool>  excludeDockerfilesInFolders = fileSystemInfo => !foldersToExcludeFromDockerfileBuild.Any(d=> fileSystemInfo.Path.FullPath.EndsWith(d, StringComparison.OrdinalIgnoreCase));
-
 Task("DockerBuild")
     .Description("Builds a Docker image.")
     .DoesForEach(
-        GetFiles(
-            "./**/Dockerfile",
-             new GlobberSettings
-                {
-                    Predicate = excludeDockerfilesInFolders
-                }), 
-    dockerfile =>
-    {
-        tag = tag ?? dockerfile.GetDirectory().GetDirectoryName().ToLower();
-        var version = GetVersion();
-        var gitCommitSha = GetGitCommitSha();
-
-        // Docker buildx allows you to build Docker images for multiple platforms (including x64, x86 and ARM64) and
-        // push them at the same time. To enable buildx, you may need to enable experimental support with these commands:
-        // docker buildx create --name builder --driver docker-container --use
-        // docker buildx inspect --bootstrap
-        // To stop using buildx remove the buildx parameter and the --platform, --progress switches.
-        // See https://github.com/docker/buildx
-        StartProcess(
-            "docker",
-            new ProcessArgumentBuilder()
-                .Append("buildx")
-                .Append("build")
-                .AppendSwitchQuoted("--platform", platform)
-                .AppendSwitchQuoted("--progress", BuildSystem.IsLocalBuild ? "auto" : "plain")
-                .Append($"--push={push}")
-                .AppendSwitchQuoted("--tag", $"{tag}:{version}")
-                .AppendSwitchQuoted("--build-arg", $"Configuration={configuration}")
-                .AppendSwitchQuoted("--label", $"org.opencontainers.image.created={DateTimeOffset.UtcNow:o}")
-                .AppendSwitchQuoted("--label", $"org.opencontainers.image.revision={gitCommitSha}")
-                .AppendSwitchQuoted("--label", $"org.opencontainers.image.version={version}")
-                .AppendSwitchQuoted("--file", dockerfile.ToString())
-                .Append(".")
-                .RenderSafe());
-
-        // If you'd rather not use buildx, then you can uncomment these lines instead.
-        // StartProcess(
-        //     "docker",
-        //     new ProcessArgumentBuilder()
-        //         .Append("build")
-        //         .AppendSwitchQuoted("--tag", $"{tag}:{version}")
-        //         .AppendSwitchQuoted("--build-arg", $"Configuration={configuration}")
-        //         .AppendSwitchQuoted("--label", $"org.opencontainers.image.created={DateTimeOffset.UtcNow:o}")
-        //         .AppendSwitchQuoted("--label", $"org.opencontainers.image.revision={gitCommitSha}")
-        //         .AppendSwitchQuoted("--label", $"org.opencontainers.image.version={version}")
-        //         .AppendSwitchQuoted("--file", dockerfile.ToString())
-        //         .Append(".")
-        //         .RenderSafe());
-        // if (push)
-        // {
-        //     StartProcess(
-        //         "docker",
-        //         new ProcessArgumentBuilder()
-        //             .AppendSwitchQuoted("push", $"{tag}:{version}")
-        //             .RenderSafe());
-        // }
-
-        string GetVersion()
+        GetFiles("./**/Dockerfile").Where(x => !x.Segments.Contains(".devcontainer")),
+        dockerfile =>
         {
-            var directoryBuildPropsFilePath = GetFiles("Directory.Build.props").Single().ToString();
-            var directoryBuildPropsDocument = System.Xml.Linq.XDocument.Load(directoryBuildPropsFilePath);
-            var preReleasePhase = directoryBuildPropsDocument.Descendants("MinVerDefaultPreReleasePhase").Single().Value;
+            tag = tag ?? dockerfile.GetDirectory().GetDirectoryName().ToLower();
+            var version = GetVersion();
+            var gitCommitSha = GetGitCommitSha();
 
+            // Docker buildx allows you to build Docker images for multiple platforms (including x64, x86 and ARM64) and
+            // push them at the same time. To enable buildx, you may need to enable experimental support with these commands:
+            // docker buildx create --name builder --driver docker-container --use
+            // docker buildx inspect --bootstrap
+            // To stop using buildx remove the buildx parameter and the --platform, --progress switches.
+            // See https://github.com/docker/buildx
             StartProcess(
-                "dotnet",
-                new ProcessSettings()
-                    .WithArguments(x => x
-                        .Append("minver")
-                        .AppendSwitch("--default-pre-release-phase", preReleasePhase))
-                    .SetRedirectStandardOutput(true),
-                    out var versionLines);
-            return versionLines.LastOrDefault();
-        }
+                "docker",
+                new ProcessArgumentBuilder()
+                    .Append("buildx")
+                    .Append("build")
+                    .AppendSwitchQuoted("--platform", platform)
+                    .AppendSwitchQuoted("--progress", BuildSystem.IsLocalBuild ? "auto" : "plain")
+                    .Append($"--push={push}")
+                    .AppendSwitchQuoted("--tag", $"{tag}:{version}")
+                    .AppendSwitchQuoted("--build-arg", $"Configuration={configuration}")
+                    .AppendSwitchQuoted("--label", $"org.opencontainers.image.created={DateTimeOffset.UtcNow:o}")
+                    .AppendSwitchQuoted("--label", $"org.opencontainers.image.revision={gitCommitSha}")
+                    .AppendSwitchQuoted("--label", $"org.opencontainers.image.version={version}")
+                    .AppendSwitchQuoted("--file", dockerfile.ToString())
+                    .Append(".")
+                    .RenderSafe());
 
-        string GetGitCommitSha()
-        {
-            StartProcess(
-                "git",
-                new ProcessSettings()
-                    .WithArguments(x => x.Append("rev-parse HEAD"))
-                    .SetRedirectStandardOutput(true),
-                out var shaLines);
-            return shaLines.LastOrDefault();
-        }
-    });
+            // If you'd rather not use buildx, then you can uncomment these lines instead.
+            // StartProcess(
+            //     "docker",
+            //     new ProcessArgumentBuilder()
+            //         .Append("build")
+            //         .AppendSwitchQuoted("--tag", $"{tag}:{version}")
+            //         .AppendSwitchQuoted("--build-arg", $"Configuration={configuration}")
+            //         .AppendSwitchQuoted("--label", $"org.opencontainers.image.created={DateTimeOffset.UtcNow:o}")
+            //         .AppendSwitchQuoted("--label", $"org.opencontainers.image.revision={gitCommitSha}")
+            //         .AppendSwitchQuoted("--label", $"org.opencontainers.image.version={version}")
+            //         .AppendSwitchQuoted("--file", dockerfile.ToString())
+            //         .Append(".")
+            //         .RenderSafe());
+            // if (push)
+            // {
+            //     StartProcess(
+            //         "docker",
+            //         new ProcessArgumentBuilder()
+            //             .AppendSwitchQuoted("push", $"{tag}:{version}")
+            //             .RenderSafe());
+            // }
+
+            string GetVersion()
+            {
+                var directoryBuildPropsFilePath = GetFiles("Directory.Build.props").Single().ToString();
+                var directoryBuildPropsDocument = System.Xml.Linq.XDocument.Load(directoryBuildPropsFilePath);
+                var preReleasePhase = directoryBuildPropsDocument.Descendants("MinVerDefaultPreReleasePhase").Single().Value;
+
+                StartProcess(
+                    "dotnet",
+                    new ProcessSettings()
+                        .WithArguments(x => x
+                            .Append("minver")
+                            .AppendSwitch("--default-pre-release-phase", preReleasePhase))
+                        .SetRedirectStandardOutput(true),
+                        out var versionLines);
+                return versionLines.LastOrDefault();
+            }
+
+            string GetGitCommitSha()
+            {
+                StartProcess(
+                    "git",
+                    new ProcessSettings()
+                        .WithArguments(x => x.Append("rev-parse HEAD"))
+                        .SetRedirectStandardOutput(true),
+                    out var shaLines);
+                return shaLines.LastOrDefault();
+            }
+        });
 
 Task("Default")
     .Description("Cleans, restores NuGet packages, builds the solution, runs unit tests and then builds a Docker image.")

--- a/Source/GraphQLTemplate/build.cake
+++ b/Source/GraphQLTemplate/build.cake
@@ -49,123 +49,129 @@ Task("Build")
 
 Task("Test")
     .Description("Runs unit tests and outputs test results to the artefacts directory.")
-    .DoesForEach(GetFiles("./Tests/**/*.csproj"), project =>
-    {
-        DotNetTest(
-            project.ToString(),
-            new DotNetTestSettings()
-            {
-                Blame = true,
-                Collectors = new string[] { "Code Coverage", "XPlat Code Coverage" },
-                Configuration = configuration,
-                Loggers = new string[]
+    .DoesForEach(
+        GetFiles("./Tests/**/*.csproj"),
+        project =>
+        {
+            DotNetTest(
+                project.ToString(),
+                new DotNetTestSettings()
                 {
-                    $"trx;LogFileName={project.GetFilenameWithoutExtension()}.trx",
-                    $"html;LogFileName={project.GetFilenameWithoutExtension()}.html",
-                },
-                NoBuild = true,
-                NoRestore = true,
-                ResultsDirectory = artefactsDirectory,
-            });
-    });
+                    Blame = true,
+                    Collectors = new string[] { "Code Coverage", "XPlat Code Coverage" },
+                    Configuration = configuration,
+                    Loggers = new string[]
+                    {
+                        $"trx;LogFileName={project.GetFilenameWithoutExtension()}.trx",
+                        $"html;LogFileName={project.GetFilenameWithoutExtension()}.html",
+                    },
+                    NoBuild = true,
+                    NoRestore = true,
+                    ResultsDirectory = artefactsDirectory,
+                });
+        });
 
 Task("Publish")
     .Description("Publishes the solution.")
-    .DoesForEach(GetFiles("./Source/**/*.csproj"), project =>
-    {
-        DotNetPublish(
-            project.ToString(),
-            new DotNetPublishSettings()
-            {
-                Configuration = configuration,
-                NoBuild = true,
-                NoRestore = true,
-                OutputDirectory = artefactsDirectory + Directory("Publish"),
-            });
-    });
+    .DoesForEach(
+        GetFiles("./Source/**/*.csproj"),
+        project =>
+        {
+            DotNetPublish(
+                project.ToString(),
+                new DotNetPublishSettings()
+                {
+                    Configuration = configuration,
+                    NoBuild = true,
+                    NoRestore = true,
+                    OutputDirectory = artefactsDirectory + Directory("Publish"),
+                });
+        });
 
 #if (Docker)
 Task("DockerBuild")
     .Description("Builds a Docker image.")
-    .DoesForEach(GetFiles("./**/Dockerfile"), dockerfile =>
-    {
-        tag = tag ?? dockerfile.GetDirectory().GetDirectoryName().ToLower();
-        var version = GetVersion();
-        var gitCommitSha = GetGitCommitSha();
-
-        // Docker buildx allows you to build Docker images for multiple platforms (including x64, x86 and ARM64) and
-        // push them at the same time. To enable buildx, you may need to enable experimental support with these commands:
-        // docker buildx create --name builder --driver docker-container --use
-        // docker buildx inspect --bootstrap
-        // To stop using buildx remove the buildx parameter and the --platform, --progress switches.
-        // See https://github.com/docker/buildx
-        StartProcess(
-            "docker",
-            new ProcessArgumentBuilder()
-                .Append("buildx")
-                .Append("build")
-                .AppendSwitchQuoted("--platform", platform)
-                .AppendSwitchQuoted("--progress", BuildSystem.IsLocalBuild ? "auto" : "plain")
-                .Append($"--push={push}")
-                .AppendSwitchQuoted("--tag", $"{tag}:{version}")
-                .AppendSwitchQuoted("--build-arg", $"Configuration={configuration}")
-                .AppendSwitchQuoted("--label", $"org.opencontainers.image.created={DateTimeOffset.UtcNow:o}")
-                .AppendSwitchQuoted("--label", $"org.opencontainers.image.revision={gitCommitSha}")
-                .AppendSwitchQuoted("--label", $"org.opencontainers.image.version={version}")
-                .AppendSwitchQuoted("--file", dockerfile.ToString())
-                .Append(".")
-                .RenderSafe());
-
-        // If you'd rather not use buildx, then you can uncomment these lines instead.
-        // StartProcess(
-        //     "docker",
-        //     new ProcessArgumentBuilder()
-        //         .Append("build")
-        //         .AppendSwitchQuoted("--tag", $"{tag}:{version}")
-        //         .AppendSwitchQuoted("--build-arg", $"Configuration={configuration}")
-        //         .AppendSwitchQuoted("--label", $"org.opencontainers.image.created={DateTimeOffset.UtcNow:o}")
-        //         .AppendSwitchQuoted("--label", $"org.opencontainers.image.revision={gitCommitSha}")
-        //         .AppendSwitchQuoted("--label", $"org.opencontainers.image.version={version}")
-        //         .AppendSwitchQuoted("--file", dockerfile.ToString())
-        //         .Append(".")
-        //         .RenderSafe());
-        // if (push)
-        // {
-        //     StartProcess(
-        //         "docker",
-        //         new ProcessArgumentBuilder()
-        //             .AppendSwitchQuoted("push", $"{tag}:{version}")
-        //             .RenderSafe());
-        // }
-
-        string GetVersion()
+    .DoesForEach(
+        GetFiles("./**/Dockerfile").Where(x => !x.Segments.Contains(".devcontainer")),
+        dockerfile =>
         {
-            var directoryBuildPropsFilePath = GetFiles("Directory.Build.props").Single().ToString();
-            var directoryBuildPropsDocument = System.Xml.Linq.XDocument.Load(directoryBuildPropsFilePath);
-            var preReleasePhase = directoryBuildPropsDocument.Descendants("MinVerDefaultPreReleasePhase").Single().Value;
+            tag = tag ?? dockerfile.GetDirectory().GetDirectoryName().ToLower();
+            var version = GetVersion();
+            var gitCommitSha = GetGitCommitSha();
 
+            // Docker buildx allows you to build Docker images for multiple platforms (including x64, x86 and ARM64) and
+            // push them at the same time. To enable buildx, you may need to enable experimental support with these commands:
+            // docker buildx create --name builder --driver docker-container --use
+            // docker buildx inspect --bootstrap
+            // To stop using buildx remove the buildx parameter and the --platform, --progress switches.
+            // See https://github.com/docker/buildx
             StartProcess(
-                "dotnet",
-                new ProcessSettings()
-                    .WithArguments(x => x
-                        .Append("minver")
-                        .AppendSwitch("--default-pre-release-phase", preReleasePhase))
-                    .SetRedirectStandardOutput(true),
-                    out var versionLines);
-            return versionLines.LastOrDefault();
-        }
+                "docker",
+                new ProcessArgumentBuilder()
+                    .Append("buildx")
+                    .Append("build")
+                    .AppendSwitchQuoted("--platform", platform)
+                    .AppendSwitchQuoted("--progress", BuildSystem.IsLocalBuild ? "auto" : "plain")
+                    .Append($"--push={push}")
+                    .AppendSwitchQuoted("--tag", $"{tag}:{version}")
+                    .AppendSwitchQuoted("--build-arg", $"Configuration={configuration}")
+                    .AppendSwitchQuoted("--label", $"org.opencontainers.image.created={DateTimeOffset.UtcNow:o}")
+                    .AppendSwitchQuoted("--label", $"org.opencontainers.image.revision={gitCommitSha}")
+                    .AppendSwitchQuoted("--label", $"org.opencontainers.image.version={version}")
+                    .AppendSwitchQuoted("--file", dockerfile.ToString())
+                    .Append(".")
+                    .RenderSafe());
 
-        string GetGitCommitSha()
-        {
-            StartProcess(
-                "git",
-                new ProcessSettings()
-                    .WithArguments(x => x.Append("rev-parse HEAD"))
-                    .SetRedirectStandardOutput(true),
-                out var shaLines);
-            return shaLines.LastOrDefault();
-        }
-    });
+            // If you'd rather not use buildx, then you can uncomment these lines instead.
+            // StartProcess(
+            //     "docker",
+            //     new ProcessArgumentBuilder()
+            //         .Append("build")
+            //         .AppendSwitchQuoted("--tag", $"{tag}:{version}")
+            //         .AppendSwitchQuoted("--build-arg", $"Configuration={configuration}")
+            //         .AppendSwitchQuoted("--label", $"org.opencontainers.image.created={DateTimeOffset.UtcNow:o}")
+            //         .AppendSwitchQuoted("--label", $"org.opencontainers.image.revision={gitCommitSha}")
+            //         .AppendSwitchQuoted("--label", $"org.opencontainers.image.version={version}")
+            //         .AppendSwitchQuoted("--file", dockerfile.ToString())
+            //         .Append(".")
+            //         .RenderSafe());
+            // if (push)
+            // {
+            //     StartProcess(
+            //         "docker",
+            //         new ProcessArgumentBuilder()
+            //             .AppendSwitchQuoted("push", $"{tag}:{version}")
+            //             .RenderSafe());
+            // }
+
+            string GetVersion()
+            {
+                var directoryBuildPropsFilePath = GetFiles("Directory.Build.props").Single().ToString();
+                var directoryBuildPropsDocument = System.Xml.Linq.XDocument.Load(directoryBuildPropsFilePath);
+                var preReleasePhase = directoryBuildPropsDocument.Descendants("MinVerDefaultPreReleasePhase").Single().Value;
+
+                StartProcess(
+                    "dotnet",
+                    new ProcessSettings()
+                        .WithArguments(x => x
+                            .Append("minver")
+                            .AppendSwitch("--default-pre-release-phase", preReleasePhase))
+                        .SetRedirectStandardOutput(true),
+                        out var versionLines);
+                return versionLines.LastOrDefault();
+            }
+
+            string GetGitCommitSha()
+            {
+                StartProcess(
+                    "git",
+                    new ProcessSettings()
+                        .WithArguments(x => x.Append("rev-parse HEAD"))
+                        .SetRedirectStandardOutput(true),
+                    out var shaLines);
+                return shaLines.LastOrDefault();
+            }
+        });
 
 Task("Default")
     .Description("Cleans, restores NuGet packages, builds the solution, runs unit tests and then builds a Docker image.")

--- a/Source/NuGetTemplate/build.cake
+++ b/Source/NuGetTemplate/build.cake
@@ -38,25 +38,27 @@ Task("Build")
 
 Task("Test")
     .Description("Runs unit tests and outputs test results to the artefacts directory.")
-    .DoesForEach(GetFiles("./Tests/**/*.csproj"), project =>
-    {
-        DotNetTest(
-            project.ToString(),
-            new DotNetTestSettings()
-            {
-                Blame = true,
-                Collectors = new string[] { "Code Coverage", "XPlat Code Coverage" },
-                Configuration = configuration,
-                Loggers = new string[]
+    .DoesForEach(
+        GetFiles("./Tests/**/*.csproj"),
+        project =>
+        {
+            DotNetTest(
+                project.ToString(),
+                new DotNetTestSettings()
                 {
-                    $"trx;LogFileName={project.GetFilenameWithoutExtension()}.trx",
-                    $"html;LogFileName={project.GetFilenameWithoutExtension()}.html",
-                },
-                NoBuild = true,
-                NoRestore = true,
-                ResultsDirectory = artefactsDirectory,
-            });
-    });
+                    Blame = true,
+                    Collectors = new string[] { "Code Coverage", "XPlat Code Coverage" },
+                    Configuration = configuration,
+                    Loggers = new string[]
+                    {
+                        $"trx;LogFileName={project.GetFilenameWithoutExtension()}.trx",
+                        $"html;LogFileName={project.GetFilenameWithoutExtension()}.html",
+                    },
+                    NoBuild = true,
+                    NoRestore = true,
+                    ResultsDirectory = artefactsDirectory,
+                });
+        });
 
 Task("Pack")
     .Description("Creates NuGet packages and outputs them to the artefacts directory.")

--- a/Source/OrleansTemplate/build.cake
+++ b/Source/OrleansTemplate/build.cake
@@ -13,10 +13,7 @@ var push =
     HasArgument("Push") ? Argument<bool>("Push") :
     EnvironmentVariable("Push", false);
 #endif
-#if (Docker)
-// Add directory names to exclude from the DockerBuild
-var foldersToExcludeFromDockerfileBuild = new[] { ".devcontainer" };
-#endif
+
 var artefactsDirectory = Directory("./Artefacts");
 
 Task("Clean")
@@ -52,133 +49,129 @@ Task("Build")
 
 Task("Test")
     .Description("Runs unit tests and outputs test results to the artefacts directory.")
-    .DoesForEach(GetFiles("./Tests/**/*.csproj"), project =>
-    {
-        DotNetTest(
-            project.ToString(),
-            new DotNetTestSettings()
-            {
-                Blame = true,
-                Collectors = new string[] { "Code Coverage", "XPlat Code Coverage" },
-                Configuration = configuration,
-                Loggers = new string[]
+    .DoesForEach(
+        GetFiles("./Tests/**/*.csproj"),
+        project =>
+        {
+            DotNetTest(
+                project.ToString(),
+                new DotNetTestSettings()
                 {
-                    $"trx;LogFileName={project.GetFilenameWithoutExtension()}.trx",
-                    $"html;LogFileName={project.GetFilenameWithoutExtension()}.html",
-                },
-                NoBuild = true,
-                NoRestore = true,
-                ResultsDirectory = artefactsDirectory,
-            });
-    });
+                    Blame = true,
+                    Collectors = new string[] { "Code Coverage", "XPlat Code Coverage" },
+                    Configuration = configuration,
+                    Loggers = new string[]
+                    {
+                        $"trx;LogFileName={project.GetFilenameWithoutExtension()}.trx",
+                        $"html;LogFileName={project.GetFilenameWithoutExtension()}.html",
+                    },
+                    NoBuild = true,
+                    NoRestore = true,
+                    ResultsDirectory = artefactsDirectory,
+                });
+        });
 
 Task("Publish")
     .Description("Publishes the solution.")
-    .DoesForEach(GetFiles("./Source/**/*.csproj"), project =>
-    {
-        DotNetPublish(
-            project.ToString(),
-            new DotNetPublishSettings()
-            {
-                Configuration = configuration,
-                NoBuild = true,
-                NoRestore = true,
-                OutputDirectory = artefactsDirectory + Directory("Publish"),
-            });
-    });
+    .DoesForEach(
+        GetFiles("./Source/**/*.csproj"),
+        project =>
+        {
+            DotNetPublish(
+                project.ToString(),
+                new DotNetPublishSettings()
+                {
+                    Configuration = configuration,
+                    NoBuild = true,
+                    NoRestore = true,
+                    OutputDirectory = artefactsDirectory + Directory("Publish"),
+                });
+        });
 
 #if (Docker)
-
-Func<IFileSystemInfo, bool>  excludeDockerfilesInFolders = fileSystemInfo => !foldersToExcludeFromDockerfileBuild.Any(d=> fileSystemInfo.Path.FullPath.EndsWith(d, StringComparison.OrdinalIgnoreCase));
-
 Task("DockerBuild")
     .Description("Builds a Docker image.")
     .DoesForEach(
-        GetFiles(
-            "./**/Dockerfile",
-             new GlobberSettings
-                {
-                    Predicate = excludeDockerfilesInFolders
-                }), 
-    dockerfile =>
-    {
-        tag = tag ?? dockerfile.GetDirectory().GetDirectoryName().ToLower();
-        var version = GetVersion();
-        var gitCommitSha = GetGitCommitSha();
-
-        // Docker buildx allows you to build Docker images for multiple platforms (including x64, x86 and ARM64) and
-        // push them at the same time. To enable buildx, you may need to enable experimental support with these commands:
-        // docker buildx create --name builder --driver docker-container --use
-        // docker buildx inspect --bootstrap
-        // To stop using buildx remove the buildx parameter and the --platform, --progress switches.
-        // See https://github.com/docker/buildx
-        StartProcess(
-            "docker",
-            new ProcessArgumentBuilder()
-                .Append("buildx")
-                .Append("build")
-                .AppendSwitchQuoted("--platform", platform)
-                .AppendSwitchQuoted("--progress", BuildSystem.IsLocalBuild ? "auto" : "plain")
-                .Append($"--push={push}")
-                .AppendSwitchQuoted("--tag", $"{tag}:{version}")
-                .AppendSwitchQuoted("--build-arg", $"Configuration={configuration}")
-                .AppendSwitchQuoted("--label", $"org.opencontainers.image.created={DateTimeOffset.UtcNow:o}")
-                .AppendSwitchQuoted("--label", $"org.opencontainers.image.revision={gitCommitSha}")
-                .AppendSwitchQuoted("--label", $"org.opencontainers.image.version={version}")
-                .AppendSwitchQuoted("--file", dockerfile.ToString())
-                .Append(".")
-                .RenderSafe());
-
-        // If you'd rather not use buildx, then you can uncomment these lines instead.
-        // StartProcess(
-        //     "docker",
-        //     new ProcessArgumentBuilder()
-        //         .Append("build")
-        //         .AppendSwitchQuoted("--tag", $"{tag}:{version}")
-        //         .AppendSwitchQuoted("--build-arg", $"Configuration={configuration}")
-        //         .AppendSwitchQuoted("--label", $"org.opencontainers.image.created={DateTimeOffset.UtcNow:o}")
-        //         .AppendSwitchQuoted("--label", $"org.opencontainers.image.revision={gitCommitSha}")
-        //         .AppendSwitchQuoted("--label", $"org.opencontainers.image.version={version}")
-        //         .AppendSwitchQuoted("--file", dockerfile.ToString())
-        //         .Append(".")
-        //         .RenderSafe());
-        // if (push)
-        // {
-        //     StartProcess(
-        //         "docker",
-        //         new ProcessArgumentBuilder()
-        //             .AppendSwitchQuoted("push", $"{tag}:{version}")
-        //             .RenderSafe());
-        // }
-
-        string GetVersion()
+        GetFiles("./**/Dockerfile").Where(x => !x.Segments.Contains(".devcontainer")),
+        dockerfile =>
         {
-            var directoryBuildPropsFilePath = GetFiles("Directory.Build.props").Single().ToString();
-            var directoryBuildPropsDocument = System.Xml.Linq.XDocument.Load(directoryBuildPropsFilePath);
-            var preReleasePhase = directoryBuildPropsDocument.Descendants("MinVerDefaultPreReleasePhase").Single().Value;
+            tag = tag ?? dockerfile.GetDirectory().GetDirectoryName().ToLower();
+            var version = GetVersion();
+            var gitCommitSha = GetGitCommitSha();
 
+            // Docker buildx allows you to build Docker images for multiple platforms (including x64, x86 and ARM64) and
+            // push them at the same time. To enable buildx, you may need to enable experimental support with these commands:
+            // docker buildx create --name builder --driver docker-container --use
+            // docker buildx inspect --bootstrap
+            // To stop using buildx remove the buildx parameter and the --platform, --progress switches.
+            // See https://github.com/docker/buildx
             StartProcess(
-                "dotnet",
-                new ProcessSettings()
-                    .WithArguments(x => x
-                        .Append("minver")
-                        .AppendSwitch("--default-pre-release-phase", preReleasePhase))
-                    .SetRedirectStandardOutput(true),
-                    out var versionLines);
-            return versionLines.LastOrDefault();
-        }
+                "docker",
+                new ProcessArgumentBuilder()
+                    .Append("buildx")
+                    .Append("build")
+                    .AppendSwitchQuoted("--platform", platform)
+                    .AppendSwitchQuoted("--progress", BuildSystem.IsLocalBuild ? "auto" : "plain")
+                    .Append($"--push={push}")
+                    .AppendSwitchQuoted("--tag", $"{tag}:{version}")
+                    .AppendSwitchQuoted("--build-arg", $"Configuration={configuration}")
+                    .AppendSwitchQuoted("--label", $"org.opencontainers.image.created={DateTimeOffset.UtcNow:o}")
+                    .AppendSwitchQuoted("--label", $"org.opencontainers.image.revision={gitCommitSha}")
+                    .AppendSwitchQuoted("--label", $"org.opencontainers.image.version={version}")
+                    .AppendSwitchQuoted("--file", dockerfile.ToString())
+                    .Append(".")
+                    .RenderSafe());
 
-        string GetGitCommitSha()
-        {
-            StartProcess(
-                "git",
-                new ProcessSettings()
-                    .WithArguments(x => x.Append("rev-parse HEAD"))
-                    .SetRedirectStandardOutput(true),
-                out var shaLines);
-            return shaLines.LastOrDefault();
-        }
-    });
+            // If you'd rather not use buildx, then you can uncomment these lines instead.
+            // StartProcess(
+            //     "docker",
+            //     new ProcessArgumentBuilder()
+            //         .Append("build")
+            //         .AppendSwitchQuoted("--tag", $"{tag}:{version}")
+            //         .AppendSwitchQuoted("--build-arg", $"Configuration={configuration}")
+            //         .AppendSwitchQuoted("--label", $"org.opencontainers.image.created={DateTimeOffset.UtcNow:o}")
+            //         .AppendSwitchQuoted("--label", $"org.opencontainers.image.revision={gitCommitSha}")
+            //         .AppendSwitchQuoted("--label", $"org.opencontainers.image.version={version}")
+            //         .AppendSwitchQuoted("--file", dockerfile.ToString())
+            //         .Append(".")
+            //         .RenderSafe());
+            // if (push)
+            // {
+            //     StartProcess(
+            //         "docker",
+            //         new ProcessArgumentBuilder()
+            //             .AppendSwitchQuoted("push", $"{tag}:{version}")
+            //             .RenderSafe());
+            // }
+
+            string GetVersion()
+            {
+                var directoryBuildPropsFilePath = GetFiles("Directory.Build.props").Single().ToString();
+                var directoryBuildPropsDocument = System.Xml.Linq.XDocument.Load(directoryBuildPropsFilePath);
+                var preReleasePhase = directoryBuildPropsDocument.Descendants("MinVerDefaultPreReleasePhase").Single().Value;
+
+                StartProcess(
+                    "dotnet",
+                    new ProcessSettings()
+                        .WithArguments(x => x
+                            .Append("minver")
+                            .AppendSwitch("--default-pre-release-phase", preReleasePhase))
+                        .SetRedirectStandardOutput(true),
+                        out var versionLines);
+                return versionLines.LastOrDefault();
+            }
+
+            string GetGitCommitSha()
+            {
+                StartProcess(
+                    "git",
+                    new ProcessSettings()
+                        .WithArguments(x => x.Append("rev-parse HEAD"))
+                        .SetRedirectStandardOutput(true),
+                    out var shaLines);
+                return shaLines.LastOrDefault();
+            }
+        });
 
 Task("Default")
     .Description("Cleans, restores NuGet packages, builds the solution, runs unit tests and then builds a Docker image.")

--- a/build.cake
+++ b/build.cake
@@ -85,42 +85,44 @@ Task("InstallDeveloperCertificate")
 
 Task("Test")
     .Description("Runs unit tests and outputs test results to the artefacts directory.")
-    .DoesForEach(GetFiles("./Tests/**/*.csproj"), project =>
-    {
-        var filters = new List<string>();
-        if (!isDotnetRunEnabled)
+    .DoesForEach(
+        GetFiles("./Tests/**/*.csproj"),
+        project =>
         {
-            filters.Add("IsUsingDotnetRun=false");
-        }
-
-        if (!isDockerEnabled)
-        {
-            filters.Add("IsUsingDocker=false");
-        }
-
-        if (template is not null)
-        {
-            filters.Add($"Template={template}");
-        }
-
-        DotNetTest(
-            project.ToString(),
-            new DotNetTestSettings()
+            var filters = new List<string>();
+            if (!isDotnetRunEnabled)
             {
-                Blame = true,
-                Collectors = new string[] { "Code Coverage", "XPlat Code Coverage" },
-                Configuration = configuration,
-                Filter = string.Join("&", filters),
-                Loggers = new string[]
+                filters.Add("IsUsingDotnetRun=false");
+            }
+
+            if (!isDockerEnabled)
+            {
+                filters.Add("IsUsingDocker=false");
+            }
+
+            if (template is not null)
+            {
+                filters.Add($"Template={template}");
+            }
+
+            DotNetTest(
+                project.ToString(),
+                new DotNetTestSettings()
                 {
-                    $"trx;LogFileName={project.GetFilenameWithoutExtension()}.trx",
-                    $"html;LogFileName={project.GetFilenameWithoutExtension()}.html",
-                },
-                NoBuild = true,
-                NoRestore = true,
-                ResultsDirectory = artefactsDirectory,
-            });
-    });
+                    Blame = true,
+                    Collectors = new string[] { "Code Coverage", "XPlat Code Coverage" },
+                    Configuration = configuration,
+                    Filter = string.Join("&", filters),
+                    Loggers = new string[]
+                    {
+                        $"trx;LogFileName={project.GetFilenameWithoutExtension()}.trx",
+                        $"html;LogFileName={project.GetFilenameWithoutExtension()}.html",
+                    },
+                    NoBuild = true,
+                    NoRestore = true,
+                    ResultsDirectory = artefactsDirectory,
+                });
+        });
 
 Task("Pack")
     .Description("Creates NuGet packages and outputs them to the artefacts directory.")


### PR DESCRIPTION
@ElanHasson I found a slightly easier way to look for .devcontainer directories. Also filling in the GraphQL project cake file.