### PR TITLE
Bump all actions.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -29,12 +29,12 @@ jobs:
         os: [ubuntu-latest, windows-latest, macOS-latest]
     steps:
       - name: "Checkout"
-        uses: actions/checkout@v3.0.2
+        uses: actions/checkout@v3
         with:
           lfs: true
           fetch-depth: 0
       - name: "Install .NET SDK"
-        uses: actions/setup-dotnet@v2.1.0
+        uses: actions/setup-dotnet@v3
         with:
           dotnet-version: |
             3.1.x
@@ -50,7 +50,7 @@ jobs:
         run: dotnet cake --target=Pack
         shell: pwsh
       - name: "Publish Artefacts"
-        uses: actions/upload-artifact@v3.1.0
+        uses: actions/upload-artifact@v3
         with:
           name: ${{matrix.os}}
           path: "./Artefacts"
@@ -64,12 +64,12 @@ jobs:
         os: [ubuntu-latest, windows-latest]
     steps:
       - name: "Checkout"
-        uses: actions/checkout@v3.0.2
+        uses: actions/checkout@v3
         with:
           lfs: true
           fetch-depth: 0
       - name: "Install .NET SDK"
-        uses: actions/setup-dotnet@v2.1.0
+        uses: actions/setup-dotnet@v3
         with:
           dotnet-version: |
             3.1.x
@@ -100,7 +100,7 @@ jobs:
     runs-on: windows-latest
     steps:
       - name: "Download Artefact"
-        uses: actions/download-artifact@v3.0.0
+        uses: actions/download-artifact@v3
         with:
           name: "windows-latest"
       - name: "Dotnet NuGet Add Source"
@@ -120,7 +120,7 @@ jobs:
     runs-on: windows-latest
     steps:
       - name: "Download Artefact"
-        uses: actions/download-artifact@v3.0.0
+        uses: actions/download-artifact@v3
         with:
           name: "windows-latest"
       - name: "Dotnet NuGet Push"

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -20,6 +20,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: "Draft Release"
-        uses: release-drafter/release-drafter@v5.21.0
+        uses: release-drafter/release-drafter@v5
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/Source/ApiTemplate/.github/release-drafter.yml
+++ b/Source/ApiTemplate/.github/release-drafter.yml
@@ -3,7 +3,7 @@
 # release-drafter also generates a version for your release based on GitHub labels. You can add a label of 'major',
 # 'minor' or 'patch' to determine which number in the version to increment.
 # You may need to add these labels yourself.
-# See https://github.com/release-drafter/release-drafter
+# See https://github.com/release-drafter/release-drafter@v5
 name-template: "$RESOLVED_VERSION"
 tag-template: "$RESOLVED_VERSION"
 change-template: "- $TITLE by @$AUTHOR (#$NUMBER)"

--- a/Source/ApiTemplate/.github/workflows/build.yml
+++ b/Source/ApiTemplate/.github/workflows/build.yml
@@ -29,12 +29,12 @@ jobs:
         os: [ubuntu-latest, windows-latest, macOS-latest]
     steps:
       - name: "Checkout"
-        uses: actions/checkout@v3.0.2
+        uses: actions/checkout@v3
         with:
           lfs: true
           fetch-depth: 0
       - name: "Install .NET Core SDK"
-        uses: actions/setup-dotnet@v2.1.0
+        uses: actions/setup-dotnet@v3
       - name: "Dotnet Tool Restore"
         run: dotnet tool restore
         shell: pwsh
@@ -48,7 +48,7 @@ jobs:
         run: dotnet cake --target=Publish
         shell: pwsh
       - name: "Publish Artefacts"
-        uses: actions/upload-artifact@v3.1.0
+        uses: actions/upload-artifact@v3
         with:
           name: ${{matrix.os}}
           path: "./Artefacts"
@@ -83,22 +83,22 @@ jobs:
         os: [ubuntu-latest]
     steps:
       - name: "Checkout"
-        uses: actions/checkout@v3.0.2
+        uses: actions/checkout@v3
         with:
           lfs: true
           fetch-depth: 0
       - name: "Install .NET Core SDK"
-        uses: actions/setup-dotnet@v2.1.0
+        uses: actions/setup-dotnet@v3
       - name: "Dotnet Tool Restore"
         run: dotnet tool restore
         shell: pwsh
       - name: "Install QEMU"
         id: qemu
-        uses: docker/setup-qemu-action@v1
+        uses: docker/setup-qemu-action@v2
       - name: "Available platforms"
         run: echo ${{steps.qemu.outputs.platforms}}
       - name: "Install Docker BuildX"
-        uses: docker/setup-buildx-action@v1
+        uses: docker/setup-buildx-action@v2
       - name: "Docker Login"
         if: github.ref == 'refs/heads/main' || github.event_name == 'release'
         run: echo ${{env.DOCKER_PASSWORD}} | docker login ${{env.DOCKER_REGISTRY}} --username ${{env.DOCKER_USERNAME}} --password-stdin

--- a/Source/ApiTemplate/.github/workflows/release-drafter.yml
+++ b/Source/ApiTemplate/.github/workflows/release-drafter.yml
@@ -20,6 +20,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: "Draft Release"
-        uses: release-drafter/release-drafter@v5.21.0
+        uses: release-drafter/release-drafter@v5
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/Source/GraphQLTemplate/.github/release-drafter.yml
+++ b/Source/GraphQLTemplate/.github/release-drafter.yml
@@ -3,7 +3,7 @@
 # release-drafter also generates a version for your release based on GitHub labels. You can add a label of 'major',
 # 'minor' or 'patch' to determine which number in the version to increment.
 # You may need to add these labels yourself.
-# See https://github.com/release-drafter/release-drafter
+# See https://github.com/release-drafter/release-drafter@v5
 name-template: "$RESOLVED_VERSION"
 tag-template: "$RESOLVED_VERSION"
 change-template: "- $TITLE by @$AUTHOR (#$NUMBER)"

--- a/Source/GraphQLTemplate/.github/workflows/build.yml
+++ b/Source/GraphQLTemplate/.github/workflows/build.yml
@@ -29,12 +29,12 @@ jobs:
         os: [ubuntu-latest, windows-latest, macOS-latest]
     steps:
       - name: "Checkout"
-        uses: actions/checkout@v3.0.2
+        uses: actions/checkout@v3
         with:
           lfs: true
           fetch-depth: 0
       - name: "Install .NET Core SDK"
-        uses: actions/setup-dotnet@v2.1.0
+        uses: actions/setup-dotnet@v3
       - name: "Dotnet Tool Restore"
         run: dotnet tool restore
         shell: pwsh
@@ -48,7 +48,7 @@ jobs:
         run: dotnet cake --target=Publish
         shell: pwsh
       - name: "Publish Artefacts"
-        uses: actions/upload-artifact@v3.1.0
+        uses: actions/upload-artifact@v3
         with:
           name: ${{matrix.os}}
           path: "./Artefacts"
@@ -83,22 +83,22 @@ jobs:
         os: [ubuntu-latest]
     steps:
       - name: "Checkout"
-        uses: actions/checkout@v3.0.2
+        uses: actions/checkout@v3
         with:
           lfs: true
           fetch-depth: 0
       - name: "Install .NET Core SDK"
-        uses: actions/setup-dotnet@v2.1.0
+        uses: actions/setup-dotnet@v3
       - name: "Dotnet Tool Restore"
         run: dotnet tool restore
         shell: pwsh
       - name: "Install QEMU"
         id: qemu
-        uses: docker/setup-qemu-action@v1
+        uses: docker/setup-qemu-action@v2
       - name: "Available platforms"
         run: echo ${{steps.qemu.outputs.platforms}}
       - name: "Install Docker BuildX"
-        uses: docker/setup-buildx-action@v1
+        uses: docker/setup-buildx-action@v2
       - name: "Docker Login"
         if: github.ref == 'refs/heads/main' || github.event_name == 'release'
         run: echo ${{env.DOCKER_PASSWORD}} | docker login ${{env.DOCKER_REGISTRY}} --username ${{env.DOCKER_USERNAME}} --password-stdin

--- a/Source/GraphQLTemplate/.github/workflows/release-drafter.yml
+++ b/Source/GraphQLTemplate/.github/workflows/release-drafter.yml
@@ -20,6 +20,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: "Draft Release"
-        uses: release-drafter/release-drafter@v5.21.0
+        uses: release-drafter/release-drafter@v5
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/Source/NuGetTemplate/.github/release-drafter.yml
+++ b/Source/NuGetTemplate/.github/release-drafter.yml
@@ -3,7 +3,7 @@
 # release-drafter also generates a version for your release based on GitHub labels. You can add a label of 'major',
 # 'minor' or 'patch' to determine which number in the version to increment.
 # You may need to add these labels yourself.
-# See https://github.com/release-drafter/release-drafter
+# See https://github.com/release-drafter/release-drafter@v5
 name-template: "$RESOLVED_VERSION"
 tag-template: "$RESOLVED_VERSION"
 change-template: "- $TITLE by @$AUTHOR (#$NUMBER)"

--- a/Source/NuGetTemplate/.github/workflows/build.yml
+++ b/Source/NuGetTemplate/.github/workflows/build.yml
@@ -29,12 +29,12 @@ jobs:
         os: [ubuntu-latest, windows-latest, macOS-latest]
     steps:
       - name: "Checkout"
-        uses: actions/checkout@v3.0.2
+        uses: actions/checkout@v3
         with:
           lfs: true
           fetch-depth: 0
       - name: "Install .NET Core SDK"
-        uses: actions/setup-dotnet@v2.1.0
+        uses: actions/setup-dotnet@v3
       - name: "Dotnet Tool Restore"
         run: dotnet tool restore
         shell: pwsh
@@ -48,7 +48,7 @@ jobs:
         run: dotnet cake --target=Pack
         shell: pwsh
       - name: "Publish Artefacts"
-        uses: actions/upload-artifact@v3.1.0
+        uses: actions/upload-artifact@v3
         with:
           name: ${{matrix.os}}
           path: "./Artefacts"
@@ -65,7 +65,7 @@ jobs:
     runs-on: windows-latest
     steps:
       - name: "Download Artefact"
-        uses: actions/download-artifact@v3.0.0
+        uses: actions/download-artifact@v3
         with:
           name: "windows-latest"
       - name: "Dotnet NuGet Add Source"
@@ -85,7 +85,7 @@ jobs:
     runs-on: windows-latest
     steps:
       - name: "Download Artefact"
-        uses: actions/download-artifact@v3.0.0
+        uses: actions/download-artifact@v3
         with:
           name: "windows-latest"
       - name: "Dotnet NuGet Push"

--- a/Source/NuGetTemplate/.github/workflows/release-drafter.yml
+++ b/Source/NuGetTemplate/.github/workflows/release-drafter.yml
@@ -20,6 +20,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: "Draft Release"
-        uses: release-drafter/release-drafter@v5.21.0
+        uses: release-drafter/release-drafter@v5
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/Source/OrleansTemplate/.github/release-drafter.yml
+++ b/Source/OrleansTemplate/.github/release-drafter.yml
@@ -3,7 +3,7 @@
 # release-drafter also generates a version for your release based on GitHub labels. You can add a label of 'major',
 # 'minor' or 'patch' to determine which number in the version to increment.
 # You may need to add these labels yourself.
-# See https://github.com/release-drafter/release-drafter
+# See https://github.com/release-drafter/release-drafter@v5
 name-template: "$RESOLVED_VERSION"
 tag-template: "$RESOLVED_VERSION"
 change-template: "- $TITLE by @$AUTHOR (#$NUMBER)"

--- a/Source/OrleansTemplate/.github/workflows/build.yml
+++ b/Source/OrleansTemplate/.github/workflows/build.yml
@@ -29,12 +29,12 @@ jobs:
         os: [ubuntu-latest, windows-latest, macOS-latest]
     steps:
       - name: "Checkout"
-        uses: actions/checkout@v3.0.2
+        uses: actions/checkout@v3
         with:
           lfs: true
           fetch-depth: 0
       - name: "Install .NET Core SDK"
-        uses: actions/setup-dotnet@v2.1.0
+        uses: actions/setup-dotnet@v3
       - name: "Dotnet Tool Restore"
         run: dotnet tool restore
         shell: pwsh
@@ -48,7 +48,7 @@ jobs:
         run: dotnet cake --target=Publish
         shell: pwsh
       - name: "Publish Artefacts"
-        uses: actions/upload-artifact@v3.1.0
+        uses: actions/upload-artifact@v3
         with:
           name: ${{matrix.os}}
           path: "./Artefacts"
@@ -83,22 +83,22 @@ jobs:
         os: [ubuntu-latest]
     steps:
       - name: "Checkout"
-        uses: actions/checkout@v3.0.2
+        uses: actions/checkout@v3
         with:
           lfs: true
           fetch-depth: 0
       - name: "Install .NET Core SDK"
-        uses: actions/setup-dotnet@v2.1.0
+        uses: actions/setup-dotnet@v3
       - name: "Dotnet Tool Restore"
         run: dotnet tool restore
         shell: pwsh
       - name: "Install QEMU"
         id: qemu
-        uses: docker/setup-qemu-action@v1
+        uses: docker/setup-qemu-action@v2
       - name: "Available platforms"
         run: echo ${{steps.qemu.outputs.platforms}}
       - name: "Install Docker BuildX"
-        uses: docker/setup-buildx-action@v1
+        uses: docker/setup-buildx-action@v2
       - name: "Docker Login"
         if: github.ref == 'refs/heads/main' || github.event_name == 'release'
         run: echo ${{env.DOCKER_PASSWORD}} | docker login ${{env.DOCKER_REGISTRY}} --username ${{env.DOCKER_USERNAME}} --password-stdin

--- a/Source/OrleansTemplate/.github/workflows/release-drafter.yml
+++ b/Source/OrleansTemplate/.github/workflows/release-drafter.yml
@@ -20,6 +20,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: "Draft Release"
-        uses: release-drafter/release-drafter@v5.21.0
+        uses: release-drafter/release-drafter@v5
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Set actions to use major versions, this way we stay more current with patches, have to do this less often, and are more consistent across yamls.
